### PR TITLE
WIP: Implement CSS OM API

### DIFF
--- a/node/src/error.rs
+++ b/node/src/error.rs
@@ -1,0 +1,67 @@
+pub enum CompileError<'i> {
+  ParseError(cssparser::ParseError<'i, ()>),
+  PrinterError,
+  SourceMapError(parcel_sourcemap::SourceMapError)
+}
+
+impl<'i> CompileError<'i> {
+  pub fn reason(&self) -> String {
+    match self {
+      CompileError::ParseError(e) => {
+        match &e.kind {
+          cssparser::ParseErrorKind::Basic(b) => {
+            use cssparser::BasicParseErrorKind::*;
+            match b {
+              AtRuleBodyInvalid => "Invalid at rule body".into(),
+              EndOfInput => "Unexpected end of input".into(),
+              AtRuleInvalid(name) => format!("Unknown at rule: @{}", name),
+              QualifiedRuleInvalid => "Invalid qualified rule".into(),
+              UnexpectedToken(token) => format!("Unexpected token {:?}", token)
+            }
+          },
+          _ => "Unknown error".into()
+        }
+      }
+      CompileError::PrinterError => "Printer error".into(),
+      _ => "Unknown error".into()
+    }
+  }
+}
+
+impl<'i> From<cssparser::ParseError<'i, ()>> for CompileError<'i> {
+  fn from(e: cssparser::ParseError<'i, ()>) -> CompileError<'i> {
+    CompileError::ParseError(e)
+  }
+}
+
+impl<'i> From<std::fmt::Error> for CompileError<'i> {
+  fn from(_: std::fmt::Error) -> CompileError<'i> {
+    CompileError::PrinterError
+  }
+}
+
+impl<'i> From<parcel_sourcemap::SourceMapError> for CompileError<'i> {
+  fn from(e: parcel_sourcemap::SourceMapError) -> CompileError<'i> {
+    CompileError::SourceMapError(e)
+  }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<'i> From<CompileError<'i>> for napi::Error {
+  fn from(e: CompileError) -> napi::Error {
+    match e {
+      CompileError::SourceMapError(e) => e.into(),
+      _ => napi::Error::new(napi::Status::GenericFailure, e.reason())
+    }
+  }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<'i> From<CompileError<'i>> for wasm_bindgen::JsValue {
+  fn from(e: CompileError) -> wasm_bindgen::JsValue {
+    match e {
+      CompileError::SourceMapError(e) => e.into(),
+      _ => js_sys::Error::new(&e.reason()).into()
+    }
+  }
+}

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,6 +1,18 @@
+#[macro_use]
+extern crate napi_derive;
+
 #[cfg(target_os = "macos")]
 #[global_allocator]
 static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
+#[cfg(not(target_arch = "wasm32"))]
+mod stylesheet;
+mod rule_list;
+mod rule;
+mod style_rule;
+
+mod error;
+use error::CompileError;
 
 use serde::{Serialize, Deserialize};
 use parcel_css::stylesheet::StyleSheet;
@@ -28,7 +40,7 @@ pub fn transform(config_val: JsValue) -> Result<JsValue, JsValue> {
 #[cfg(not(target_arch = "wasm32"))]
 use napi_derive::{js_function, module_exports};
 #[cfg(not(target_arch = "wasm32"))]
-use napi::{CallContext, JsObject, JsUnknown};
+use napi::{CallContext, JsObject, JsUnknown, Env};
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -87,8 +99,12 @@ fn transform(ctx: CallContext) -> napi::Result<JsUnknown> {
 
 #[cfg(not(target_arch = "wasm32"))]
 #[module_exports]
-fn init(mut exports: JsObject) -> napi::Result<()> {
+fn init(mut exports: JsObject, env: Env) -> napi::Result<()> {
   exports.create_named_method("transform", transform)?;
+  stylesheet::init(&mut exports, env)?;
+  rule_list::init(&mut exports, env)?;
+  rule::init(&mut exports, env)?;
+  style_rule::init(&mut exports, env)?;
 
   Ok(())
 }
@@ -136,72 +152,4 @@ fn compile<'i>(code: &'i str, config: &Config) -> Result<TransformResult, Compil
     code: res.into_bytes(),
     map
   })
-}
-
-enum CompileError<'i> {
-  ParseError(cssparser::ParseError<'i, ()>),
-  PrinterError,
-  SourceMapError(parcel_sourcemap::SourceMapError)
-}
-
-impl<'i> CompileError<'i> {
-  fn reason(&self) -> String {
-    match self {
-      CompileError::ParseError(e) => {
-        match &e.kind {
-          cssparser::ParseErrorKind::Basic(b) => {
-            use cssparser::BasicParseErrorKind::*;
-            match b {
-              AtRuleBodyInvalid => "Invalid at rule body".into(),
-              EndOfInput => "Unexpected end of input".into(),
-              AtRuleInvalid(name) => format!("Unknown at rule: @{}", name),
-              QualifiedRuleInvalid => "Invalid qualified rule".into(),
-              UnexpectedToken(token) => format!("Unexpected token {:?}", token)
-            }
-          },
-          _ => "Unknown error".into()
-        }
-      }
-      CompileError::PrinterError => "Printer error".into(),
-      _ => "Unknown error".into()
-    }
-  }
-}
-
-impl<'i> From<cssparser::ParseError<'i, ()>> for CompileError<'i> {
-  fn from(e: cssparser::ParseError<'i, ()>) -> CompileError<'i> {
-    CompileError::ParseError(e)
-  }
-}
-
-impl<'i> From<std::fmt::Error> for CompileError<'i> {
-  fn from(_: std::fmt::Error) -> CompileError<'i> {
-    CompileError::PrinterError
-  }
-}
-
-impl<'i> From<parcel_sourcemap::SourceMapError> for CompileError<'i> {
-  fn from(e: parcel_sourcemap::SourceMapError) -> CompileError<'i> {
-    CompileError::SourceMapError(e)
-  }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl<'i> From<CompileError<'i>> for napi::Error {
-  fn from(e: CompileError) -> napi::Error {
-    match e {
-      CompileError::SourceMapError(e) => e.into(),
-      _ => napi::Error::new(napi::Status::GenericFailure, e.reason())
-    }
-  }
-}
-
-#[cfg(target_arch = "wasm32")]
-impl<'i> From<CompileError<'i>> for wasm_bindgen::JsValue {
-  fn from(e: CompileError) -> wasm_bindgen::JsValue {
-    match e {
-      CompileError::SourceMapError(e) => e.into(),
-      _ => js_sys::Error::new(&e.reason()).into()
-    }
-  }
 }

--- a/node/src/rule.rs
+++ b/node/src/rule.rs
@@ -1,0 +1,59 @@
+use napi::{CallContext, JsString, JsObject, JsUndefined, JsFunction, Property, Ref, Result, Env};
+use std::cell::RefCell;
+use parcel_css::rules::CssRule;
+use std::convert::TryInto;
+use crate::style_rule;
+
+static mut CLASS: RefCell<Option<Ref<()>>> = RefCell::new(None);
+
+#[js_function(0)]
+fn constructor(ctx: CallContext) -> Result<JsUndefined> {
+  ctx.env.get_undefined()
+}
+
+#[js_function(0)]
+fn get_css_text(ctx: CallContext) -> Result<JsString> {
+  let this: JsObject = ctx.this_unchecked();
+  let rule: &mut CssRule = ctx.env.unwrap(&this)?;
+  let text = rule.to_css_string();
+  ctx.env.create_string_from_std(text)
+}
+
+pub fn init(exports: &mut JsObject, env: Env) -> Result<()> {
+  let stylesheet_class = env
+    .define_class("CSSRule", constructor, &[
+      Property::new(&env, "cssText")?.with_getter(get_css_text)
+    ])?;
+  let mut c = unsafe { CLASS.borrow_mut() };
+  *c = Some(env.create_reference(&stylesheet_class)?);
+  exports.set_named_property("CSSRule", stylesheet_class)?;
+
+  Ok(())
+}
+
+pub fn inherit(env: &Env, obj: JsFunction) -> Result<JsFunction> {
+  let r = unsafe { CLASS.borrow() };
+  let r = r.as_ref().unwrap();
+  let super_class: JsFunction = env.get_reference_value(&r)?;
+  let super_class_obj: JsObject = super_class.coerce_to_object()?;
+  let class_obj: JsObject = obj.coerce_to_object()?;
+
+  // Based on https://github.com/nodejs/node-addon-api/issues/229#issuecomment-383583352
+  let global = env.get_global()?;
+  let object: JsFunction = global.get_named_property("Object")?;
+  let object = object.coerce_to_object()?;
+  let set_proto: JsFunction = object.get_named_property("setPrototypeOf")?;
+  let proto: JsObject = class_obj.get_named_property("prototype")?;
+  let super_proto: JsObject = super_class_obj.get_named_property("prototype")?;
+
+  set_proto.call(None, &[&proto, &super_proto])?;
+  set_proto.call(None, &[&class_obj, &super_class_obj])?;
+  class_obj.into_unknown().try_into()
+}
+
+pub fn create(env: &Env, rule: CssRule) -> Result<JsObject> {
+  match rule {
+    CssRule::Style(_) => style_rule::create(env, rule),
+    _ => unimplemented!()
+  } 
+}

--- a/node/src/rule_list.rs
+++ b/node/src/rule_list.rs
@@ -1,0 +1,51 @@
+use napi::{CallContext, JsNumber, JsObject, JsUndefined, JsUnknown, JsFunction, Property, Ref, Result, Env};
+use std::cell::RefCell;
+use parcel_css::stylesheet::StyleSheet;
+use std::rc::Rc;
+use crate::rule;
+
+// TODO: this is probably not safe.
+static mut CLASS: RefCell<Option<Ref<()>>> = RefCell::new(None);
+
+#[js_function(0)]
+fn constructor(ctx: CallContext) -> Result<JsUndefined> {
+  ctx.env.get_undefined()
+}
+
+#[js_function(0)]
+fn get_length(ctx: CallContext) -> Result<JsNumber> {
+  let this: JsObject = ctx.this_unchecked();
+  let stylesheet: &mut Rc<RefCell<StyleSheet>> = ctx.env.unwrap(&this)?;
+  ctx.env.create_uint32(stylesheet.borrow().rules.0.len() as u32)
+}
+
+#[js_function(1)]
+fn item(ctx: CallContext) -> Result<JsObject> {
+  let this: JsObject = ctx.this_unchecked();
+  let index = ctx.get::<JsNumber>(0)?.get_uint32()?;
+  let stylesheet: &mut Rc<RefCell<StyleSheet>> = ctx.env.unwrap(&this)?;
+  let r = stylesheet.borrow().rules.0[index as usize].clone();
+  rule::create(ctx.env, r)
+}
+
+pub fn init(exports: &mut JsObject, env: Env) -> Result<()> {
+  let stylesheet_class = env
+    .define_class("CSSRuleList", constructor, &[
+      Property::new(&env, "length")?.with_getter(get_length),
+      Property::new(&env, "item")?.with_method(item)
+    ])?;
+  let mut c = unsafe { CLASS.borrow_mut() };
+  *c = Some(env.create_reference(&stylesheet_class)?);
+  exports.set_named_property("CSSRuleList", stylesheet_class)?;
+
+  Ok(())
+}
+
+pub fn create(env: &Env, list: Rc<RefCell<StyleSheet>>) -> Result<JsObject> {
+  let r = unsafe { CLASS.borrow() };
+  let r = r.as_ref().unwrap();
+  let c: JsFunction = env.get_reference_value(&r)?;
+  let mut instance = c.new::<JsUnknown>(&[])?;
+  env.wrap(&mut instance, list)?;
+  Ok(instance)
+}

--- a/node/src/style_rule.rs
+++ b/node/src/style_rule.rs
@@ -1,0 +1,45 @@
+use napi::{CallContext, JsString, JsObject, JsUndefined, JsUnknown, JsFunction, Property, Ref, Result, Env};
+use std::cell::RefCell;
+use parcel_css::rules::CssRule;
+use crate::rule;
+use cssparser::ToCss;
+
+static mut CLASS: RefCell<Option<Ref<()>>> = RefCell::new(None);
+
+#[js_function(0)]
+fn constructor(ctx: CallContext) -> Result<JsUndefined> {
+  ctx.env.get_undefined()
+}
+
+#[js_function(0)]
+fn get_selector_text(ctx: CallContext) -> Result<JsString> {
+  let this: JsObject = ctx.this_unchecked();
+  let rule: &mut CssRule = ctx.env.unwrap(&this)?;
+  let text = match rule {
+    CssRule::Style(style) => style.borrow().selectors.to_css_string(),
+    _ => unreachable!()
+  };
+  ctx.env.create_string_from_std(text)
+}
+
+pub fn init(exports: &mut JsObject, env: Env) -> Result<()> {
+  let stylesheet_class = env
+    .define_class("CSSStyleRule", constructor, &[
+      Property::new(&env, "selectorText")?.with_getter(get_selector_text)
+    ])?;
+  let stylesheet_class = rule::inherit(&env, stylesheet_class)?;
+  let mut c = unsafe { CLASS.borrow_mut() };
+  *c = Some(env.create_reference(&stylesheet_class)?);
+  exports.set_named_property("CSSStyleRule", stylesheet_class)?;
+
+  Ok(())
+}
+
+pub fn create(env: &Env, list: CssRule) -> Result<JsObject> {
+  let r = unsafe { CLASS.borrow() };
+  let r = r.as_ref().unwrap();
+  let c: JsFunction = env.get_reference_value(&r)?;
+  let mut instance = c.new::<JsUnknown>(&[])?;
+  env.wrap(&mut instance, list)?;
+  Ok(instance)
+}

--- a/node/src/stylesheet.rs
+++ b/node/src/stylesheet.rs
@@ -1,0 +1,46 @@
+use napi::{CallContext, JsObject, JsUndefined, JsString, Property, Result, Env};
+use parcel_css::stylesheet::StyleSheet;
+use crate::error::CompileError;
+use crate::rule_list;
+use std::rc::Rc;
+use std::cell::RefCell;
+
+/// https://drafts.csswg.org/cssom/#the-cssstylesheet-interface
+struct CSSStyleSheet {
+  stylesheet: Rc<RefCell<StyleSheet>>
+}
+
+#[js_function(0)]
+fn constructor(ctx: CallContext) -> Result<JsUndefined> {
+  let mut this: JsObject = ctx.this_unchecked();
+  ctx.env.wrap(&mut this, CSSStyleSheet { stylesheet: Rc::new(RefCell::new(StyleSheet::empty("test.css".into()))) })?;
+  ctx.env.get_undefined()
+}
+
+#[js_function(1)]
+fn replace_sync(ctx: CallContext) -> Result<JsUndefined> {
+  let text = ctx.get::<JsString>(0)?.into_utf8()?;
+  let text = text.as_str()?;
+  let this: JsObject = ctx.this_unchecked();
+  let s: &mut CSSStyleSheet = ctx.env.unwrap(&this)?;
+  s.stylesheet.borrow_mut().replace(text).map_err(|e| CompileError::from(e))?;
+  ctx.env.get_undefined()
+}
+
+#[js_function(0)]
+fn get_rules(ctx: CallContext) -> Result<JsObject> {
+  let this: JsObject = ctx.this_unchecked();
+  let s: &mut CSSStyleSheet = ctx.env.unwrap(&this)?;
+  rule_list::create(ctx.env, s.stylesheet.clone())
+}
+
+pub fn init(exports: &mut JsObject, env: Env) -> Result<()> {
+  let test_class = env
+    .define_class("CSSStyleSheet", constructor, &[
+      Property::new(&env, "replaceSync")?.with_method(replace_sync),
+      Property::new(&env, "cssRules")?.with_getter(get_rules)
+    ])?;
+  exports.set_named_property("CSSStyleSheet", test_class)?;
+
+  Ok(())
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -22,6 +22,7 @@ use crate::rules::{
 use crate::values::ident::CustomIdent;
 use crate::declaration::{Declaration, DeclarationBlock};
 use crate::vendor_prefix::VendorPrefix;
+use std::rc::Rc;
 
 #[derive(Eq, PartialEq, Clone)]
 pub struct CssString(RefCell<String>);
@@ -170,19 +171,19 @@ impl<'a, 'i> AtRuleParser<'i> for TopLevelRuleParser {
       let loc = start.source_location();
       let rule = match prelude {
         AtRulePrelude::Import(url, media, supports) => {
-          CssRule::Import(ImportRule {
+          CssRule::Import(Rc::new(RefCell::new(ImportRule {
             url,
             supports,
             media,
             loc
-          })
+          })))
         },
         AtRulePrelude::Namespace(prefix, url) => {
-          CssRule::Namespace(NamespaceRule {
+          CssRule::Namespace(Rc::new(RefCell::new(NamespaceRule {
             prefix,
             url,
             loc
-          })
+          })))
         },
         _ => unreachable!()
       };
@@ -335,10 +336,10 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for NestedRuleParser {
             properties.push(decl);
           }
         }
-        Ok(CssRule::FontFace(FontFaceRule {
+        Ok(CssRule::FontFace(Rc::new(RefCell::new(FontFaceRule {
           properties,
           loc
-        }))
+        }))))
       },
       // AtRuleBlockPrelude::FontFeatureValues(family_names) => {
       //     let context = ParserContext::new_with_rule_type(
@@ -365,27 +366,27 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for NestedRuleParser {
           }
         }
 
-        Ok(CssRule::CounterStyle(CounterStyleRule {
+        Ok(CssRule::CounterStyle(Rc::new(RefCell::new(CounterStyleRule {
           name,
           declarations: DeclarationBlock {
             declarations
           },
           loc
-        }))
+        }))))
       },
       AtRulePrelude::Media(query) => {
-        Ok(CssRule::Media(MediaRule {
+        Ok(CssRule::Media(Rc::new(RefCell::new(MediaRule {
           query,
           rules: self.parse_nested_rules(input),
           loc
-        }))
+        }))))
       },
       AtRulePrelude::Supports(condition) => {
-        Ok(CssRule::Supports(SupportsRule {
+        Ok(CssRule::Supports(Rc::new(RefCell::new(SupportsRule {
           condition,
           rules: self.parse_nested_rules(input),
           loc
-        }))
+        }))))
       },
       // AtRuleBlockPrelude::Viewport => {
       //     let context = ParserContext::new_with_rule_type(
@@ -400,12 +401,12 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for NestedRuleParser {
       // },
       AtRulePrelude::Keyframes(name, vendor_prefix) => {
         let iter = RuleListParser::new_for_nested_rule(input, KeyframeListParser);
-        Ok(CssRule::Keyframes(KeyframesRule {
+        Ok(CssRule::Keyframes(Rc::new(RefCell::new(KeyframesRule {
           name,
           keyframes: iter.filter_map(Result::ok).collect(),
           vendor_prefix,
           loc
-        }))
+        }))))
       },
       AtRulePrelude::Page(selectors) => {
         let mut parser = DeclarationListParser::new(input, PropertyDeclarationParser);
@@ -415,13 +416,13 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for NestedRuleParser {
             declarations.push(decl);
           }
         }
-        Ok(CssRule::Page(PageRule {
+        Ok(CssRule::Page(Rc::new(RefCell::new(PageRule {
           selectors,
           declarations: DeclarationBlock {
             declarations
           },
           loc
-        }))
+        }))))
       },
       // AtRuleBlockPrelude::Document(condition) => {
       //     if !cfg!(feature = "gecko") {
@@ -475,14 +476,14 @@ impl<'a, 'b, 'i> QualifiedRuleParser<'i> for NestedRuleParser {
       }
     }
 
-    Ok(CssRule::Style(StyleRule {
+    Ok(CssRule::Style(Rc::new(RefCell::new(StyleRule {
       selectors,
       vendor_prefix: VendorPrefix::empty(),
       declarations: DeclarationBlock {
         declarations
       },
       loc
-    }))
+    }))))
   }
 }
 

--- a/src/stylesheet.rs
+++ b/src/stylesheet.rs
@@ -13,7 +13,20 @@ pub struct StyleSheet {
 }
 
 impl StyleSheet {
+  pub fn empty(filename: String) -> StyleSheet {
+    StyleSheet {
+      filename,
+      rules: CssRuleList(Vec::new())
+    }
+  }
+
   pub fn parse<'i>(filename: String, code: &'i str) -> Result<StyleSheet, ParseError<'i, ()>> {
+    let mut sheet = StyleSheet::empty(filename);
+    sheet.replace(code)?;
+    Ok(sheet)
+  }
+
+  pub fn replace<'i>(&mut self, code: &'i str) -> Result<(), ParseError<'i, ()>> {
     let mut input = ParserInput::new(&code);
     let mut parser = Parser::new(&mut input);
     let rule_list_parser = RuleListParser::new_for_stylesheet(&mut parser, TopLevelRuleParser {});
@@ -28,10 +41,8 @@ impl StyleSheet {
       rules.push(rule)
     }
 
-    Ok(StyleSheet {
-      filename,
-      rules: CssRuleList(rules)
-    })
+    self.rules = CssRuleList(rules);
+    Ok(())
   }
 
   pub fn minify(&mut self, targets: Option<Browsers>) {

--- a/test.js
+++ b/test.js
@@ -1,6 +1,29 @@
 const css = require('./native');
 const fs = require('fs');
 
+console.log(css);
+let {CSSStyleSheet, CSSStyleRule, CSSRule} = css;
+let stylesheet = new CSSStyleSheet();
+let rules = stylesheet.cssRules;
+console.log(rules.length)
+
+stylesheet.replaceSync(`
+.foo {
+  color: red;
+}
+
+.bar {
+  color: green;
+}
+`);
+
+console.log(rules.length)
+console.log(rules.item(0) instanceof CSSStyleRule, rules.item(0) instanceof CSSRule);
+console.log(rules.item(0).cssText);
+console.log(rules.item(0).selectorText);
+
+return;
+
 if (process.argv[process.argv.length - 1] !== __filename) {
   let opts = {
     filename: process.argv[process.argv.length - 1],


### PR DESCRIPTION
Implementing the [CSS OM](https://drafts.csswg.org/cssom/) and [CSS Typed OM](https://drafts.css-houdini.org/css-typed-om-1/) specs in the Node crate, to be exposed as the JS API.

Still kinda figuring out how best to do this. There is some weird Napi hackery to make sure memory is managed correctly. Maybe there is an easier way.