### PR TITLE
Feature proposal: save and load playground state as URLHash

### DIFF
--- a/playground/playground.js
+++ b/playground/playground.js
@@ -1,12 +1,84 @@
-import init, {transform} from '../node/pkg';
+import init, {transform} from '../node/pkg/parcel_css_node.js';
 
 let enc = new TextEncoder();
 let dec = new TextDecoder();
 let inputs = document.querySelectorAll('input[type=number]');
 
-async function update() {
-  await init();
+function loadPlaygroundState() {
+  const hash = window.location.hash.slice(1);
+  try {
+    const playgroundState = JSON.parse(decodeURIComponent(hash));
+    reflectPlaygroundState(playgroundState);
+  } catch {
+    const initialPlaygroundState = {
+      minify: true,
+      targets: {
+        chrome: 95 << 16,
+      },
+      source: `.foo {
+  background: yellow;
+      
+  -webkit-border-radius: 2px;
+  -moz-border-radius: 2px;
+  border-radius: 2px;
+  
+  -webkit-transition: background 200ms;
+  -moz-transition: background 200ms;
+  transition: background 200ms;
+}`,
+    };
 
+    reflectPlaygroundState(initialPlaygroundState);
+  }
+}
+
+function reflectPlaygroundState(playgroundState) {
+  if (typeof playgroundState.minify !== 'undefined') {
+    minify.checked = playgroundState.minify;
+  }
+
+  if (playgroundState.targets) {
+    const {targets} = playgroundState;
+    for (const target in targets) {
+      const value = targets[target];
+      if (value) {
+        for (const input of Array.from(inputs)) {
+          if (input.id === target) {
+            input.value = value >> 16;
+          }
+        }
+      }
+    }
+  }
+
+  if (playgroundState.source) {
+    source.value = playgroundState.source;
+  }
+}
+
+function savePlaygroundState() {
+  const playgroundState = {
+    minify: minify.checked,
+    targets: getTargets(),
+    source: source.value,
+  };
+
+  const hash = encodeURIComponent(JSON.stringify(playgroundState));
+
+  if (
+    typeof URL === 'function' &&
+    typeof history === 'object' &&
+    typeof history.replaceState === 'function'
+  ) {
+    const url = new URL(location.href);
+    url.hash = hash;
+    history.replaceState(null, null, url);
+  } else {
+    location.hash = hash;
+  }
+}
+
+function getTargets() {
   let targets = {};
   for (let input of inputs) {
     if (input.value !== '') {
@@ -14,15 +86,26 @@ async function update() {
     }
   }
 
+  return targets;
+}
+
+async function update() {
+  await init();
+
+  const targets = getTargets();
   let res = transform({
     filename: 'test.css',
     code: enc.encode(source.value),
     minify: minify.checked,
-    targets: Object.keys(targets).length === 0 ? null : targets
+    targets: Object.keys(targets).length === 0 ? null : targets,
   });
 
   compiled.value = dec.decode(res.code);
+
+  savePlaygroundState();
 }
+
+loadPlaygroundState();
 
 update();
 source.oninput = update;

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -1,4 +1,4 @@
-import init, {transform} from '../node/pkg/parcel_css_node.js';
+import init, {transform} from '../node/pkg';
 
 let enc = new TextEncoder();
 let dec = new TextDecoder();


### PR DESCRIPTION
## Motivation 🔥 

Hi team 👋 

`parcel-css` is a great library! I wanted to help something, and I watched this project.

As the [`prettier` playground](https://prettier.io/playground/) and [`swc` playground](https://swc.rs/playground) does, 
How about saving the input state of `parcel-css`'s playground as a URLHash and restoring it on load? This will make it easier to report and reproduce issues.

https://user-images.githubusercontent.com/42742053/145522152-f2d25c0c-87e9-4eca-9592-20ac43712370.mov


This is just a proposal, so if you don’t think it is necessary, please be free to close this PR.