### PR TITLE
Dependency analysis

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -111,10 +111,24 @@ export interface TransformAttributeOptions {
   /** Whether to enable minification. */
   minify?: boolean,
   /** The browser targets for the generated code. */
-  targets?: Targets
+  targets?: Targets,
+  /**
+   * Whether to analyze `url()` dependencies.
+   * When enabled, `url()` dependencies are replaced with hashed placeholders 
+   * that can be replaced with the final urls later (after bundling).
+   * Dependencies are returned as part of the result.
+   */
+   analyzeDependencies?: boolean
+}
+
+export interface TransformAttributeResult {
+  /** The transformed code. */
+  code: Buffer,
+  /** `@import` and `url()` dependencies, if enabled. */
+  dependencies: Dependency[] | void  
 }
 
 /**
  * Compiles a single CSS declaration list, such as an inline style attribute in HTML.
  */
-export declare function transformStyleAttribute(options: TransformAttributeOptions): Buffer;
+export declare function transformStyleAttribute(options: TransformAttributeOptions): TransformAttributeResult;

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -14,7 +14,9 @@ export interface TransformOptions {
   /** Whether to enable various draft syntax. */
   drafts?: Drafts,
   /** Whether to compile this file as a CSS module. */
-  cssModules?: boolean
+  cssModules?: boolean,
+  /** Whether to analyze dependencies (e.g. `@import` and `url()`). */
+  analyzeDependencies?: boolean
 }
 
 export interface Drafts {
@@ -28,7 +30,9 @@ export interface TransformResult {
   /** The generated source map, if enabled. */
   map: Buffer | void,
   /** CSS module exports, if enabled. */
-  exports: CSSModuleExports | void
+  exports: CSSModuleExports | void,
+  /** `@import` and `url()` dependencies, if enabled. */
+  dependencies: Dependency[] | void
 }
 
 export type CSSModuleExports = {
@@ -52,6 +56,32 @@ export interface DependencyCSSModuleExport {
     /** The dependency specifier for the referenced file. */
     specifier: string
   }
+}
+
+export type Dependency = ImportDependency | UrlDependency;
+
+export interface ImportDependency {
+  type: 'import',
+  url: string,
+  media: string | null,
+  supports: string | null,
+  loc: SourceLocation
+}
+
+export interface UrlDependency {
+  type: 'url',
+  url: string,
+  loc: SourceLocation
+}
+
+export interface SourceLocation {
+  start: Location,
+  end: Location
+}
+
+export interface Location {
+  line: number,
+  column: number
 }
 
 /**

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -15,7 +15,12 @@ export interface TransformOptions {
   drafts?: Drafts,
   /** Whether to compile this file as a CSS module. */
   cssModules?: boolean,
-  /** Whether to analyze dependencies (e.g. `@import` and `url()`). */
+  /**
+   * Whether to analyze dependencies (e.g. `@import` and `url()`).
+   * When enabled, `@import` rules are removed, and `url()` dependencies
+   * are replaced with hashed placeholders that can be replaced with the final
+   * urls later (after bundling). Dependencies are returned as part of the result.
+   */
   analyzeDependencies?: boolean
 }
 
@@ -62,25 +67,35 @@ export type Dependency = ImportDependency | UrlDependency;
 
 export interface ImportDependency {
   type: 'import',
+  /** The url of the `@import` dependency. */
   url: string,
+  /** The media query for the `@import` rule. */
   media: string | null,
+  /** The `supports()` query for the `@import` rule. */
   supports: string | null,
+  /** The source location where the `@import` rule was found. */
   loc: SourceLocation
 }
 
 export interface UrlDependency {
   type: 'url',
+  /** The url of the dependency. */
   url: string,
+  /** The source location where the `url()` was found. */
   loc: SourceLocation
 }
 
 export interface SourceLocation {
+  /** The start location of the dependency. */
   start: Location,
+  /** The end location (inclusive) of the dependency. */
   end: Location
 }
 
 export interface Location {
+  /** The line number (1-based). */
   line: number,
+  /** The column number (0-based). */
   column: number
 }
 

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -27,11 +27,12 @@ pub fn transform(config_val: JsValue) -> Result<JsValue, JsValue> {
 
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen(js_name = "transformStyleAttribute")]
-pub fn transform_style_attribute(config_val: JsValue) -> Result<Vec<u8>, JsValue> {
+pub fn transform_style_attribute(config_val: JsValue) -> Result<JsValue, JsValue> {
   let config: AttrConfig = from_value(config_val).map_err(JsValue::from)?;
   let code = unsafe { std::str::from_utf8_unchecked(&config.code) };
   let res = compile_attr(code, &config)?;
-  Ok(res)
+  let serializer = Serializer::new().serialize_maps_as_objects(true);
+  res.serialize(&serializer).map_err(JsValue::from)
 }
 
 // ---------------------------------------------
@@ -85,7 +86,7 @@ fn transform_style_attribute(ctx: CallContext) -> napi::Result<JsUnknown> {
   let res = compile_attr(code, &config);
 
   match res {
-    Ok(res) => Ok(ctx.env.create_buffer_with_data(res)?.into_unknown()),
+    Ok(res) => ctx.env.to_js_value(&res),
     Err(err) => err.throw(ctx, None, code)
   }
 }
@@ -164,18 +165,36 @@ fn compile<'i>(code: &'i str, config: &Config) -> Result<TransformResult, Compil
 }
 
 #[derive(Serialize, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct AttrConfig {
   #[serde(with = "serde_bytes")]
   pub code: Vec<u8>,
   pub targets: Option<Browsers>,
-  pub minify: Option<bool>
+  pub minify: Option<bool>,
+  pub analyze_dependencies: Option<bool>
 }
 
-fn compile_attr<'i>(code: &'i str, config: &AttrConfig) -> Result<Vec<u8>, CompileError<'i>> {
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AttrResult {
+  #[serde(with = "serde_bytes")]
+  code: Vec<u8>,
+  dependencies: Option<Vec<Dependency>>
+}
+
+fn compile_attr<'i>(code: &'i str, config: &AttrConfig) -> Result<AttrResult, CompileError<'i>> {
   let mut attr = StyleAttribute::parse(&code)?;
   attr.minify(config.targets); // TODO: should this be conditional?
-  let res = attr.to_css(config.minify.unwrap_or(false), config.targets)?;
-  Ok(res.into_bytes())
+  let res = attr.to_css(PrinterOptions {
+    minify: config.minify.unwrap_or(false),
+    source_map: false,
+    targets: config.targets,
+    analyze_dependencies: config.analyze_dependencies.unwrap_or(false)
+  })?;
+  Ok(AttrResult {
+    code: res.code.into_bytes(),
+    dependencies: res.dependencies
+  })
 }
 
 enum CompileError<'i> {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -6,6 +6,7 @@ use serde::{Serialize, Deserialize};
 use parcel_css::stylesheet::{StyleSheet, StyleAttribute, ParserOptions, PrinterOptions};
 use parcel_css::targets::Browsers;
 use parcel_css::css_modules::CssModuleExports;
+use parcel_css::dependencies::Dependency;
 
 // ---------------------------------------------
 
@@ -57,7 +58,8 @@ struct TransformResult {
   code: Vec<u8>,
   #[serde(with = "serde_bytes")]
   map: Option<Vec<u8>>,
-  exports: Option<CssModuleExports>
+  exports: Option<CssModuleExports>,
+  dependencies: Option<Vec<Dependency>>
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -109,7 +111,8 @@ struct Config {
   pub minify: Option<bool>,
   pub source_map: Option<bool>,
   pub drafts: Option<Drafts>,
-  pub css_modules: Option<bool>
+  pub css_modules: Option<bool>,
+  pub analyze_dependencies: Option<bool>
 }
 
 #[derive(Serialize, Debug, Deserialize, Default)]
@@ -130,7 +133,8 @@ fn compile<'i>(code: &'i str, config: &Config) -> Result<TransformResult, Compil
   let res = stylesheet.to_css(PrinterOptions {
     minify: config.minify.unwrap_or(false),
     source_map: config.source_map.unwrap_or(false),
-    targets: config.targets
+    targets: config.targets,
+    analyze_dependencies: config.analyze_dependencies.unwrap_or(false)
   })?;
 
   let map = if let Some(mut source_map) = res.source_map {
@@ -154,7 +158,8 @@ fn compile<'i>(code: &'i str, config: &Config) -> Result<TransformResult, Compil
   Ok(TransformResult {
     code: res.code.into_bytes(),
     map,
-    exports: res.exports
+    exports: res.exports,
+    dependencies: res.dependencies
   })
 }
 

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -1,0 +1,102 @@
+use crate::rules::import::ImportRule;
+use crate::values::url::Url;
+use serde::Serialize;
+use cssparser::SourceLocation;
+use crate::printer::Printer;
+use crate::traits::ToCss;
+use crate::css_modules::hash;
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum Dependency {
+  Import(ImportDependency),
+  Url(UrlDependency)
+}
+
+impl From<&ImportRule> for Dependency {
+  fn from(rule: &ImportRule) -> Dependency {
+    Dependency::Import(rule.into())
+  }
+}
+
+#[derive(Serialize)]
+pub struct ImportDependency {
+  pub url: String,
+  pub supports: Option<String>,
+  pub media: Option<String>,
+  pub loc: SourceRange
+}
+
+impl From<&ImportRule> for ImportDependency {
+  fn from(rule: &ImportRule) -> ImportDependency {
+    let supports = if let Some(supports) = &rule.supports {
+      let mut s = String::new();
+      let mut printer = Printer::new("", &mut s, None, false, None);
+      supports.to_css(&mut printer).unwrap();
+      Some(s)
+    } else {
+      None
+    };
+
+    let media = if !rule.media.media_queries.is_empty() {
+      let mut s = String::new();
+      let mut printer = Printer::new("", &mut s, None, false, None);
+      rule.media.to_css(&mut printer).unwrap();
+      Some(s)
+    } else {
+      None
+    };
+
+    ImportDependency {
+      url: rule.url.clone(),
+      supports,
+      media,
+      loc: SourceRange::new(rule.loc, 8, rule.url.len() + 2) // TODO: what about @import url(...)?
+    }
+  }
+}
+
+#[derive(Serialize)]
+pub struct UrlDependency {
+  pub url: String,
+  pub placeholder: String,
+  pub loc: SourceRange
+}
+
+impl UrlDependency {
+  pub fn new(url: &Url, filename: &str) -> UrlDependency {
+    let placeholder = hash(&format!("{}_{}", filename, url.url));
+    UrlDependency {
+      url: url.url.clone(),
+      placeholder,
+      loc: SourceRange::new(url.loc, 4, url.url.len())
+    }
+  }
+}
+
+#[derive(Serialize)]
+pub struct SourceRange {
+  pub start: Location,
+  pub end: Location,
+}
+
+#[derive(Serialize)]
+pub struct Location {
+  pub line: u32,
+  pub column: u32
+}
+
+impl SourceRange {
+  fn new(loc: SourceLocation, offset: u32, len: usize) -> SourceRange {
+    SourceRange {
+      start: Location {
+        line: loc.line + 1,
+        column: loc.column + offset
+      },
+      end: Location {
+        line: loc.line + 1,
+        column: loc.column + offset + (len as u32) - 1
+      }
+    }
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,8 @@ mod tests {
   fn attr_test(source: &str, expected: &str, minify: bool) {
     let mut attr = StyleAttribute::parse(source).unwrap();
     attr.minify(None);
-    let res = attr.to_css(minify, None).unwrap();
-    assert_eq!(res, expected);
+    let res = attr.to_css(PrinterOptions { minify, ..PrinterOptions::default() }).unwrap();
+    assert_eq!(res.code, expected);
   }
 
   fn nesting_test(source: &str, expected: &str) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod prefixes;
 pub mod vendor_prefix;
 pub mod targets;
 pub mod css_modules;
+pub mod dependencies;
 
 #[cfg(test)]
 mod tests {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -4,8 +4,10 @@ use parcel_sourcemap::{SourceMap, OriginalLocation};
 use crate::vendor_prefix::VendorPrefix;
 use crate::targets::Browsers;
 use crate::css_modules::CssModule;
+use crate::dependencies::Dependency;
 
 pub(crate) struct Printer<'a, W> {
+  pub filename: &'a str,
   dest: &'a mut W,
   source_map: Option<&'a mut SourceMap>,
   indent: u8,
@@ -17,17 +19,20 @@ pub(crate) struct Printer<'a, W> {
   /// the vendor prefix of whatever is being printed.
   pub vendor_prefix: VendorPrefix,
   pub in_calc: bool,
-  pub css_module: Option<CssModule<'a>>
+  pub css_module: Option<CssModule<'a>>,
+  pub dependencies: Option<&'a mut Vec<Dependency>>
 }
 
 impl<'a, W: Write + Sized> Printer<'a, W> {
   pub fn new(
+    filename: &'a str,
     dest: &'a mut W,
     source_map: Option<&'a mut SourceMap>,
     minify: bool,
     targets: Option<Browsers>
   ) -> Printer<'a, W> {
     Printer {
+      filename,
       dest,
       source_map,
       indent: 0,
@@ -37,7 +42,8 @@ impl<'a, W: Write + Sized> Printer<'a, W> {
       targets,
       vendor_prefix: VendorPrefix::empty(),
       in_calc: false,
-      css_module: None
+      css_module: None,
+      dependencies: None
     }
   }
 

--- a/src/properties/transform.rs
+++ b/src/properties/transform.rs
@@ -48,13 +48,13 @@ impl ToCss for TransformList {
       if let Some(matrix) = self.to_matrix() {
         // Generate based on the original transforms.
         let mut base = String::new();
-        self.to_css_base(&mut Printer::new(&mut base, None, true, None))?;
+        self.to_css_base(&mut Printer::new(dest.filename, &mut base, None, true, None))?;
 
         // Decompose the matrix into transform functions if possible.
         // If the resulting length is shorter than the original, use it.
         if let Some(d) = matrix.decompose() {
           let mut decomposed = String::new();
-          d.to_css_base(&mut Printer::new(&mut decomposed, None, true, None))?;
+          d.to_css_base(&mut Printer::new(dest.filename, &mut decomposed, None, true, None))?;
           if decomposed.len() < base.len() {
             base = decomposed;
           }
@@ -63,9 +63,9 @@ impl ToCss for TransformList {
         // Also generate a matrix() or matrix3d() representation and compare that.
         let mut mat = String::new();
         if let Some(matrix) = matrix.to_matrix2d() {
-          Transform::Matrix(matrix).to_css(&mut Printer::new(&mut mat, None, true, None))?
+          Transform::Matrix(matrix).to_css(&mut Printer::new(dest.filename, &mut mat, None, true, None))?
         } else {
-          Transform::Matrix3d(matrix).to_css(&mut Printer::new(&mut mat, None, true, None))?
+          Transform::Matrix3d(matrix).to_css(&mut Printer::new(dest.filename, &mut mat, None, true, None))?
         }
 
         if mat.len() < base.len() {

--- a/src/properties/ui.rs
+++ b/src/properties/ui.rs
@@ -4,6 +4,7 @@ use crate::values::color::CssColor;
 use crate::macros::{enum_property, shorthand_property};
 use crate::printer::Printer;
 use smallvec::SmallVec;
+use crate::values::url::Url;
 
 // https://www.w3.org/TR/2021/WD-css-ui-4-20210316/#resize
 enum_property!(Resize,
@@ -18,13 +19,13 @@ enum_property!(Resize,
 /// https://www.w3.org/TR/2021/WD-css-ui-4-20210316/#cursor
 #[derive(Debug, Clone, PartialEq)]
 pub struct CursorImage {
-  pub url: String,
+  pub url: Url,
   pub hotspot: Option<(f32, f32)>
 }
 
 impl Parse for CursorImage {
   fn parse<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ()>> {
-    let url = input.expect_url()?.as_ref().to_owned();
+    let url = Url::parse(input)?;
     let hotspot = if let Ok(x) = input.try_parse(f32::parse) {
       let y = f32::parse(input)?;
       Some((x, y))
@@ -41,10 +42,7 @@ impl Parse for CursorImage {
 
 impl ToCss for CursorImage {
   fn to_css<W>(&self, dest: &mut Printer<W>) -> std::fmt::Result where W: std::fmt::Write {
-    {
-      use cssparser::ToCss;
-      Token::UnquotedUrl(CowRcStr::from(self.url.as_ref())).to_css(dest)?;
-    }
+    self.url.to_css(dest)?;
 
     if let Some((x, y)) = self.hotspot {
       dest.write_char(' ')?;

--- a/src/rules/font_face.rs
+++ b/src/rules/font_face.rs
@@ -5,6 +5,7 @@ use crate::properties::font::{FontFamily, FontStyle, FontWeight, FontStretch};
 use crate::values::size::Size2D;
 use crate::properties::custom::CustomProperty;
 use crate::macros::enum_property;
+use crate::values::url::Url;
 
 #[derive(Debug, PartialEq)]
 pub struct FontFaceRule {
@@ -56,13 +57,13 @@ impl ToCss for Source {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct UrlSource {
-  pub url: String,
+  pub url: Url,
   pub format: Option<Format>
 }
 
 impl Parse for UrlSource {
   fn parse<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ()>> {
-    let url = input.expect_url()?.as_ref().to_owned();
+    let url = Url::parse(input)?;
 
     let format = if input.try_parse(|input| input.expect_function_matching("format")).is_ok() {
       Some(input.parse_nested_block(Format::parse)?)
@@ -76,8 +77,7 @@ impl Parse for UrlSource {
 
 impl ToCss for UrlSource {
   fn to_css<W>(&self, dest: &mut Printer<W>) -> std::fmt::Result where W: std::fmt::Write {
-    use cssparser::ToCss;
-    Token::UnquotedUrl(CowRcStr::from(self.url.as_ref())).to_css(dest)?;
+    self.url.to_css(dest)?;
     if let Some(format) = &self.format {
       dest.whitespace()?;
       dest.write_str("format(")?;

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -184,6 +184,14 @@ impl ToCssWithContext for CssRuleList {
     let mut last_without_block = false;
 
     for rule in &self.0 {
+      // Skip @import rules if collecting dependencies.
+      if let CssRule::Import(rule) = &rule {
+        if let Some(dependencies) = &mut dest.dependencies {
+          dependencies.push(rule.into());
+          continue;
+        }
+      }
+
       if first {
         first = false;
       } else {

--- a/src/stylesheet.rs
+++ b/src/stylesheet.rs
@@ -75,7 +75,7 @@ impl StyleSheet {
 
     let mut printer = Printer::new(&self.filename, &mut dest, source_map.as_mut(), options.minify, options.targets);
 
-   let mut dependencies = if options.analyze_dependencies {
+    let mut dependencies = if options.analyze_dependencies {
       Some(Vec::new())
     } else {
       None
@@ -133,9 +133,19 @@ impl StyleAttribute {
     self.declarations.minify(&mut handler, &mut important_handler);
   }
 
-  pub fn to_css(&self, minify: bool, targets: Option<Browsers>) -> Result<String, std::fmt::Error> {
+  pub fn to_css(&self, options: PrinterOptions) -> Result<ToCssResult, std::fmt::Error> {
+    assert_eq!(options.source_map, false, "Source maps are not supported for style attributes");
+
     let mut dest = String::new();
-    let mut printer = Printer::new("", &mut dest, None, minify, targets);
+    let mut printer = Printer::new("", &mut dest, None, options.minify, options.targets);
+
+    let mut dependencies = if options.analyze_dependencies {
+      Some(Vec::new())
+    } else {
+      None
+    };
+
+    printer.dependencies = dependencies.as_mut();
 
     let declarations = &self.declarations.declarations;
     let len = declarations.len();
@@ -147,6 +157,11 @@ impl StyleAttribute {
       }
     }
 
-    Ok(dest)
+    Ok(ToCssResult {
+      code: dest,
+      source_map: None,
+      exports: None,
+      dependencies
+    })
   }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -23,7 +23,7 @@ pub(crate) trait ToCss {
   #[inline]
   fn to_css_string(&self) -> String {
       let mut s = String::new();
-      let mut printer = Printer::new(&mut s, None, false, None);
+      let mut printer = Printer::new("", &mut s, None, false, None);
       self.to_css(&mut printer).unwrap();
       s
   }

--- a/src/values/mod.rs
+++ b/src/values/mod.rs
@@ -15,3 +15,4 @@ pub mod number;
 pub mod gradient;
 pub mod resolution;
 pub mod ratio;
+pub mod url;

--- a/src/values/url.rs
+++ b/src/values/url.rs
@@ -2,7 +2,6 @@ use cssparser::*;
 use crate::traits::{Parse, ToCss};
 use crate::printer::Printer;
 use crate::dependencies::{Dependency, UrlDependency};
-use crate::css_modules::hash;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Url {

--- a/src/values/url.rs
+++ b/src/values/url.rs
@@ -1,0 +1,63 @@
+use cssparser::*;
+use crate::traits::{Parse, ToCss};
+use crate::printer::Printer;
+use crate::dependencies::{Dependency, UrlDependency};
+use crate::css_modules::hash;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Url {
+  pub url: String,
+  pub loc: SourceLocation
+}
+
+impl Parse for Url {
+  fn parse<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ()>> {
+    let loc = input.current_source_location();
+    let url = input.expect_url()?.as_ref().to_owned();
+    Ok(Url { url, loc })
+  }
+}
+
+impl ToCss for Url {
+  fn to_css<W>(&self, dest: &mut Printer<W>) -> std::fmt::Result where W: std::fmt::Write {
+    let dep = if dest.dependencies.is_some() {
+      Some(UrlDependency::new(self, dest.filename))
+    } else {
+      None
+    };
+
+    let url = if let Some(dep) = &dep {
+      &dep.placeholder
+    } else {
+      &self.url
+    };
+
+    use cssparser::ToCss;
+    if dest.minify {
+      let mut buf = String::new();
+      Token::UnquotedUrl(CowRcStr::from(url.as_ref())).to_css(&mut buf)?;
+
+      // If the unquoted url is longer than it would be quoted (e.g. `url("...")`)
+      // then serialize as a string and choose the shorter version.
+      if buf.len() > url.len() + 7 {
+        let mut buf2 = String::new();
+        serialize_string(&url, &mut buf2)?;
+        if buf2.len() + 5 < buf.len() {
+          dest.write_str("url(")?;
+          dest.write_str(&buf2)?;
+          return dest.write_char(')')
+        }
+      }
+
+      dest.write_str(&buf)?;
+    } else {
+      Token::UnquotedUrl(CowRcStr::from(url.as_ref())).to_css(dest)?;
+    }
+
+    if let Some(dependencies) = &mut dest.dependencies {
+      dependencies.push(Dependency::Url(dep.unwrap()))
+    }
+
+    Ok(())
+  }
+}

--- a/test.js
+++ b/test.js
@@ -37,6 +37,9 @@ let res = css.transform({
     opera: 10 << 16 | 5 << 8
   },
   code: Buffer.from(`
+  @import "foo.css";
+  @import "bar.css" print;
+  @import "baz.css" supports(display: grid);
 
   .foo {
     composes: bar;
@@ -46,13 +49,16 @@ let res = css.transform({
 
   .bar {
     color: red;
+    background: url(test.jpg);
   }
 `),
   drafts: {
     nesting: true
   },
-  cssModules: true
+  cssModules: true,
+  analyzeDependencies: true
 });
 
 console.log(res.code.toString());
 console.log(res.exports);
+console.log(require('util').inspect(res.dependencies, { colors: true, depth: 50 }));


### PR DESCRIPTION
#18

Collects `@import` and `url()` dependencies and returns descriptors for them when the `analyzeDependencies` option is true. Also removes `@import` rules completely and replaces urls with placeholders during printing. This is needed for bundling, but may be too Parcel-specific... Should it be a separate option? 🤔 