### PR TITLE
Chore: fix wrong url into TypeScript definition file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A CSS parser, transformer, and minifier written in Rust.
 
 ### From JavaScript
 
-See the [TypeScript definitions](blob/master/node/index.d.ts) for full API docs.
+See the [TypeScript definitions](https://github.com/parcel-bundler/parcel-css/blob/master/node/index.d.ts) for full API docs.
 
 Here is a simple example that compiles the input CSS for Safari 13.2, and minifies the output.
 


### PR DESCRIPTION
## Motivation 🔥 

Hi ! 👋 

I noticed the link into TypeScript definitions in ["From JavaScript"](https://github.com/parcel-bundler/parcel-css#from-javascript) section is wrong. The relative path in `README.md` is resolved with branch prefix automatically, so `blob/master/path` is resolved to `https://github.com/org/repo/blob/master/blob/master/path`.

FYI: https://github.blog/2013-01-31-relative-links-in-markup-files/

I fixed this. In the first place, the rule of relative path of GitHub is difficult to understand, so I decided to specify it with an absolute path.