### PR TITLE
WIP: Remove unused variables

### DIFF
--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -117,7 +117,8 @@ struct Config {
   pub css_modules: Option<bool>,
   pub analyze_dependencies: Option<bool>,
   pub pseudo_classes: Option<OwnedPseudoClasses>,
-  pub unused_symbols: Option<HashSet<String>>
+  pub unused_symbols: Option<HashSet<String>>,
+  pub remove_unused_vars: Option<bool>
 }
 
 #[derive(Debug, Deserialize)]
@@ -154,7 +155,8 @@ fn compile<'i>(code: &'i str, config: &Config) -> Result<TransformResult, Compil
       Some(o) => o.nesting,
       None => false
     },
-    css_modules: config.css_modules.unwrap_or(false)
+    css_modules: config.css_modules.unwrap_or(false),
+    collect_used_vars: config.remove_unused_vars.unwrap_or(false)
   })?;
   stylesheet.minify(MinifyOptions {
     targets: config.targets,

--- a/src/properties/mod.rs
+++ b/src/properties/mod.rs
@@ -63,6 +63,7 @@ use crate::error::{ParserError, PrinterError};
 use crate::logical::LogicalProperty;
 use crate::targets::Browsers;
 use crate::prefixes::Feature;
+use std::collections::HashSet;
 
 macro_rules! define_properties {
   (
@@ -279,7 +280,7 @@ macro_rules! define_properties {
     }
 
     impl Property {
-      pub fn parse<'i, 't>(name: CowRcStr<'i>, input: &mut Parser<'i, 't>, options: &ParserOptions) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+      pub fn parse<'i, 't>(name: CowRcStr<'i>, input: &mut Parser<'i, 't>, options: &ParserOptions, used_vars: &mut Option<HashSet<String>>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
         let state = input.state();
         match name.as_ref() {
           $(
@@ -296,7 +297,7 @@ macro_rules! define_properties {
               // and stored as an enum rather than a string. This lets property handlers more easily deal with it.
               // Ideally we'd only do this if var() or env() references were seen, but err on the safe side for now.
               input.reset(&state);
-              return Ok(Property::Unparsed(UnparsedProperty::parse(PropertyId::$property$((<$vp>::None))?, input)?))
+              return Ok(Property::Unparsed(UnparsedProperty::parse(PropertyId::$property$((<$vp>::None))?, input, used_vars)?))
             }
 
             $(
@@ -310,7 +311,7 @@ macro_rules! define_properties {
                 }
 
                 input.reset(&state);
-                return Ok(Property::Unparsed(UnparsedProperty::parse(PropertyId::$property(prefix), input)?))  
+                return Ok(Property::Unparsed(UnparsedProperty::parse(PropertyId::$property(prefix), input, used_vars)?))  
               }
             )*
           )+
@@ -318,7 +319,7 @@ macro_rules! define_properties {
         }
 
         input.reset(&state);
-        return Ok(Property::Custom(CustomProperty::parse(name, input)?))
+        return Ok(Property::Custom(CustomProperty::parse(name, input, used_vars)?))
       }
 
       #[allow(dead_code)]

--- a/src/rules/font_face.rs
+++ b/src/rules/font_face.rs
@@ -287,7 +287,7 @@ impl<'i> cssparser::DeclarationParser<'i> for FontFaceDeclarationParser {
     }
 
     input.reset(&state);
-    return Ok(FontFaceProperty::Custom(CustomProperty::parse(name, input)?))
+    return Ok(FontFaceProperty::Custom(CustomProperty::parse(name, input, &mut None)?))
   }
 }
 

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -95,7 +95,8 @@ pub(crate) struct MinifyContext<'a> {
   pub handler: &'a mut DeclarationHandler,
   pub important_handler: &'a mut DeclarationHandler,
   pub logical_properties: &'a mut LogicalProperties,
-  pub unused_symbols: &'a HashSet<String>
+  pub unused_symbols: &'a HashSet<String>,
+  pub used_vars: &'a Option<HashSet<String>>
 }
 
 impl CssRuleList {
@@ -164,7 +165,7 @@ impl CssRuleList {
             // Merge declarations if the selectors are equivalent, and both are compatible with all targets.
             if style.selectors == last_style_rule.selectors && style.is_compatible(*context.targets) && last_style_rule.is_compatible(*context.targets) && style.rules.0.is_empty() && last_style_rule.rules.0.is_empty() {
               last_style_rule.declarations.declarations.extend(style.declarations.declarations.drain(..));
-              last_style_rule.declarations.minify(context.handler, context.important_handler, context.logical_properties);
+              last_style_rule.declarations.minify(context.handler, context.important_handler, context.logical_properties, context.used_vars);
               continue
             } else if style.declarations == last_style_rule.declarations && style.rules.0.is_empty() && last_style_rule.rules.0.is_empty() {
               // Append the selectors to the last rule if the declarations are the same, and all selectors are compatible.

--- a/src/rules/style.rs
+++ b/src/rules/style.rs
@@ -35,7 +35,7 @@ impl StyleRule {
       }
     }
 
-    self.declarations.minify(context.handler, context.important_handler, context.logical_properties);
+    self.declarations.minify(context.handler, context.important_handler, context.logical_properties, context.used_vars);
 
     if !self.rules.0.is_empty() {
       self.rules.minify(context, unused);


### PR DESCRIPTION
This is a draft to get feedback. Please let me know what you think in the comments.

I'm not sure if this is a good idea, but I would like a way to remove CSS variables that aren't referenced. For example, in a design system you might have a ton of variables and only use a subset of them in a particular file. For example:

```css
.foo {
  --used: blue;
  --unused: red;
}

.bar {
  color: var(--used);
}
```

becomes:

```css
.foo{--used:blue}.bar{color:var(--used)}
```

This is very unsafe, so would need to be opt-in. Variable names are global so could be referenced from another CSS file, or from JavaScript. Also code splitting might break it if the variables were defined in a different bundle from where they are used. So this would basically only work if you are building a library and guarantee that only a single CSS file will be output, on which you can run this optimization pass.

## Alternatives

I am hoping there is a better way. One idea I had was to make variables kinda like CSS modules. The names would get hashed, and if you wanted to reference a variable from a different file, you'd need to do so explicitly.

vars.css:
```css
.theme {
  --color: blue;
  --font: Helvetica;
}
```

component.css:
```css
.button {
  color: var(--color from "vars.css");
}
```

compiled output:

```css
.theme {
  --color_a8fd: blue;
}

.button {
  color: var(--color_a8fd);
}
```

Unfortunately, that syntax gets pretty annoying pretty fast if you have a lot of variables. If anyone has any ideas, let me know!