### PR TITLE
Add support for custom media queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,7 @@ dependencies = [
  "lazy_static",
  "parcel_selectors",
  "parcel_sourcemap",
+ "retain_mut",
  "serde",
  "smallvec",
 ]
@@ -616,6 +617,12 @@ checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core",
 ]
+
+[[package]]
+name = "retain_mut"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11000e6ba5020e53e7cc26f73b91ae7d5496b4977851479edb66b694c0675c21"
 
 [[package]]
 name = "rkyv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ parcel_sourcemap = "2.0.0"
 data-encoding = "2.3.2"
 lazy_static = "1.4.0"
 clap = { version = "3.0.6", features = ["derive"] }
+retain_mut = "0.1.5"
 
 [dev-dependencies]
 indoc = "1.0.3"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A CSS parser, transformer, and minifier written in Rust.
 - **Vendor prefixing** – `@parcel/css` accepts a list of browser targets, and automatically adds (and removes) vendor prefixes.
 - **Syntax lowering** – `@parcel/css` parses modern CSS syntax, and generates more compatible output where needed, based on browser targets.
   - CSS Nesting (draft spec)
+  - Custom media queries (draft spec)
   - Logical properties
   - CSS Level 4 Color syntax
     - Space separated components in `rgb` and `hsl` functions
@@ -99,14 +100,15 @@ You should also add a `browserslist` property to your `package.json`, which defi
 
 While Parcel CSS handles the most commonly used PostCSS plugins like `autoprefixer`, `postcss-preset-env`, and CSS modules, you may still need PostCSS for more custom plugins like TailwindCSS. If that's the case, just add @parcel/transformer-postcss before @parcel/transformer-css-experimental, and your PostCSS config will be picked up automatically. You can remove the plugins listed above from your PostCSS config, and they'll be handled by Parcel CSS.
 
-You can also configure Parcel CSS in the `package.json` in the root of your project. Currently, three options are supported: `drafts`, which can be used to enable CSS nesting, `pseudoClasses`, which allows replacing some pseudo classes like `:focus-visible` with normal classes that can be applied via JavaScript (e.g. polyfills), and `cssModules`, which enables CSS modules globally rather than only for files ending in `.module.css`.
+You can also configure Parcel CSS in the `package.json` in the root of your project. Currently, three options are supported: `drafts`, which can be used to enable CSS nesting and custom media queries, `pseudoClasses`, which allows replacing some pseudo classes like `:focus-visible` with normal classes that can be applied via JavaScript (e.g. polyfills), and `cssModules`, which enables CSS modules globally rather than only for files ending in `.module.css`.
 
 ```json
 {
   "@parcel/transformer-css": {
     "cssModules": true,
     "drafts": {
-      "nesting": true
+      "nesting": true,
+      "customMedia": true
     },
     "pseudoClasses": {
       "focusVisible": "focus-ring"

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -37,7 +37,9 @@ export interface TransformOptions {
 
 export interface Drafts {
   /** Whether to enable CSS nesting. */
-  nesting?: boolean
+  nesting?: boolean,
+  /** Whether to enable @custom-media rules. */
+  customMedia?: boolean
 }
 
 export interface PseudoClasses {

--- a/playground/index.html
+++ b/playground/index.html
@@ -103,6 +103,8 @@
         </label>
       </div>
       <textarea id="source">
+@custom-media --modern (color), (hover);
+
 .foo {
   background: yellow;
 
@@ -115,6 +117,12 @@
   transition: background 200ms;
 
   &.bar {
+    color: green;
+  }
+}
+
+@media (--modern) and (width > 1024px) {
+  .a {
     color: green;
   }
 }</textarea>

--- a/playground/index.html
+++ b/playground/index.html
@@ -84,6 +84,7 @@
         <label><input id="analyzeDependencies" type="checkbox"> Analyze dependencies</label>
         <h3>Draft syntax</h3>
         <label><input id="nesting" type="checkbox" checked> Nesting</label>
+        <label><input id="customMedia" type="checkbox" checked> Custom media queries</label>
         <h3>Targets</h3>
         <div class="targets">
           <label><span>Chrome: </span><input id="chrome" type="number" value="95"></label>

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -40,6 +40,10 @@ function reflectPlaygroundState(playgroundState) {
     nesting.checked = playgroundState.nesting;
   }
 
+  if (typeof playgroundState.customMedia !== 'undefined') {
+    customMedia.checked = playgroundState.customMedia;
+  }
+
   if (playgroundState.targets) {
     const {targets} = playgroundState;
     for (let input of inputs) {
@@ -61,6 +65,7 @@ function savePlaygroundState() {
   const playgroundState = {
     minify: minify.checked,
     nesting: nesting.checked,
+    customMedia: customMedia.checked,
     cssModules: cssModules.checked,
     analyzeDependencies: analyzeDependencies.checked,
     targets: getTargets(),
@@ -104,7 +109,8 @@ async function update() {
     minify: minify.checked,
     targets: Object.keys(targets).length === 0 ? null : targets,
     drafts: {
-      nesting: nesting.checked
+      nesting: nesting.checked,
+      customMedia: customMedia.checked
     },
     cssModules: cssModules.checked,
     analyzeDependencies: analyzeDependencies.checked,

--- a/scripts/build-prefixes.js
+++ b/scripts/build-prefixes.js
@@ -187,6 +187,9 @@ for (let feature of cssFeatures) {
   addValue(compat, browserMap, feature);
 }
 
+// No browser supports custom media queries yet.
+addValue(compat, {}, 'custom-media-queries');
+
 let mdnFeatures = {
   doublePositionGradients: mdn.css.types.image.gradient['radial-gradient'].doubleposition.__compat.support,
   clamp: mdn.css.types.clamp.__compat.support,

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -29,6 +29,7 @@ pub enum Feature {
   CssSel2,
   CssSel3,
   CssSelection,
+  CustomMediaQueries,
   Dialog,
   DoublePositionGradients,
   FormValidation,
@@ -1086,6 +1087,7 @@ impl Feature {
         }
       }
       Feature::CssNesting |
+      Feature::CustomMediaQueries |
       Feature::MediaIntervalSyntax => {}
       Feature::DoublePositionGradients => {
         if let Some(version) = browsers.chrome {

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,41 @@ impl<'i> ParserError<'i> {
   }
 }
 
+#[derive(Debug, PartialEq)]
+pub enum MinifyError {
+  UnsupportedCustomMediaBooleanLogic {
+    media_loc: SourceLocation,
+    custom_media_loc: SourceLocation
+  },
+  CustomMediaNotDefined {
+    name: String,
+    loc: SourceLocation
+  },
+  CircularCustomMedia {
+    name: String,
+    loc: SourceLocation
+  }
+}
+
+impl MinifyError {
+  pub fn reason(&self) -> String {
+    match self {
+      MinifyError::UnsupportedCustomMediaBooleanLogic {..} => "Boolean logic with media types in @custom-media rules is not supported by Parcel CSS.".into(),
+      MinifyError::CustomMediaNotDefined { name, .. } => format!("Custom media query {} is not defined.", name),
+      MinifyError::CircularCustomMedia { name, .. } => format!("Circular custom media query {} detected.", name)
+    }
+  }
+
+  pub fn loc(&self) -> SourceLocation {
+    match self {
+      MinifyError::UnsupportedCustomMediaBooleanLogic { media_loc, .. } => *media_loc,
+      MinifyError::CustomMediaNotDefined { loc, .. } => *loc,
+      MinifyError::CircularCustomMedia { loc, .. } => *loc
+    }
+  }
+}
+
+
 #[derive(Debug)]
 pub enum PrinterError {
   FmtError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,29 +20,30 @@ mod logical;
 
 #[cfg(test)]
 mod tests {
-  use crate::stylesheet::*;
+  use crate::{stylesheet::*, error::MinifyError};
   use crate::targets::Browsers;
+  use cssparser::SourceLocation;
   use indoc::indoc;
-  use std::collections::HashMap;
+  use std::{collections::HashMap};
   use crate::css_modules::{CssModuleExports, CssModuleExport, CssModuleReference};
 
   fn test(source: &str, expected: &str) {
     let mut stylesheet = StyleSheet::parse("test.css".into(), source, ParserOptions::default()).unwrap();
-    stylesheet.minify(MinifyOptions::default());
+    stylesheet.minify(MinifyOptions::default()).unwrap();
     let res = stylesheet.to_css(PrinterOptions::default()).unwrap();
     assert_eq!(res.code, expected);
   }
 
   fn minify_test(source: &str, expected: &str) {
     let mut stylesheet = StyleSheet::parse("test.css".into(), source, ParserOptions::default()).unwrap();
-    stylesheet.minify(MinifyOptions::default());
+    stylesheet.minify(MinifyOptions::default()).unwrap();
     let res = stylesheet.to_css(PrinterOptions { minify: true, ..PrinterOptions::default() }).unwrap();
     assert_eq!(res.code, expected);
   }
 
   fn prefix_test(source: &str, expected: &str, targets: Browsers) {
     let mut stylesheet = StyleSheet::parse("test.css".into(), source, ParserOptions::default()).unwrap();
-    stylesheet.minify(MinifyOptions { targets: Some(targets), ..MinifyOptions::default() });
+    stylesheet.minify(MinifyOptions { targets: Some(targets), ..MinifyOptions::default() }).unwrap();
     let res = stylesheet.to_css(PrinterOptions { targets: Some(targets), ..PrinterOptions::default() }).unwrap();
     assert_eq!(res.code, expected);
   }
@@ -60,24 +61,31 @@ mod tests {
       ..Browsers::default()
     });
     let mut stylesheet = StyleSheet::parse("test.css".into(), source, ParserOptions { nesting: true, ..ParserOptions::default() }).unwrap();
-    stylesheet.minify(MinifyOptions { targets, ..MinifyOptions::default() });
+    stylesheet.minify(MinifyOptions { targets, ..MinifyOptions::default() }).unwrap();
     let res = stylesheet.to_css(PrinterOptions { targets, ..PrinterOptions::default() }).unwrap();
     assert_eq!(res.code, expected);
   }
 
   fn nesting_test_no_targets(source: &str, expected: &str) {
     let mut stylesheet = StyleSheet::parse("test.css".into(), source, ParserOptions { nesting: true, ..ParserOptions::default() }).unwrap();
-    stylesheet.minify(MinifyOptions::default());
+    stylesheet.minify(MinifyOptions::default()).unwrap();
     let res = stylesheet.to_css(PrinterOptions::default()).unwrap();
     assert_eq!(res.code, expected);
   }
 
   fn css_modules_test(source: &str, expected: &str, expected_exports: CssModuleExports) {
     let mut stylesheet = StyleSheet::parse("test.css".into(), source, ParserOptions { css_modules: true, ..ParserOptions::default() }).unwrap();
-    stylesheet.minify(MinifyOptions::default());
+    stylesheet.minify(MinifyOptions::default()).unwrap();
     let res = stylesheet.to_css(PrinterOptions::default()).unwrap();
     assert_eq!(res.code, expected);
     assert_eq!(res.exports.unwrap(), expected_exports);
+  }
+
+  fn custom_media_test(source: &str, expected: &str) {
+    let mut stylesheet = StyleSheet::parse("test.css".into(), source, ParserOptions { custom_media: true, ..ParserOptions::default() }).unwrap();
+    stylesheet.minify(MinifyOptions::default()).unwrap();
+    let res = stylesheet.to_css(PrinterOptions::default()).unwrap();
+    assert_eq!(res.code, expected);
   }
 
   macro_rules! map(
@@ -3446,7 +3454,7 @@ mod tests {
     minify_test("@media (not (color)) or (hover) { .foo { color: chartreuse }}", "@media (not (color)) or (hover){.foo{color:#7fff00}}");
     minify_test("@media (example, all,), speech { .foo { color: chartreuse }}", "@media speech{.foo{color:#7fff00}}");
     minify_test("@media &test, speech { .foo { color: chartreuse }}", "@media speech{.foo{color:#7fff00}}");
-    minify_test("@media &test { .foo { color: chartreuse }}", "@media not all{.foo{color:#7fff00}}");
+    minify_test("@media &test { .foo { color: chartreuse }}", "");
     minify_test("@media (min-width: calc(200px + 40px)) { .foo { color: chartreuse }}", "@media (min-width:240px){.foo{color:#7fff00}}");
     minify_test("@media (min-width: calc(1em + 5px)) { .foo { color: chartreuse }}", "@media (min-width:calc(1em + 5px)){.foo{color:#7fff00}}");
 
@@ -9037,7 +9045,7 @@ mod tests {
     stylesheet.minify(MinifyOptions {
       unused_symbols: vec!["bar", "other_id", "fade", "circles"].iter().map(|s| String::from(*s)).collect(),
       ..MinifyOptions::default()
-    });
+    }).unwrap();
     let res = stylesheet.to_css(PrinterOptions::default()).unwrap();
     assert_eq!(res.code, expected);
 
@@ -9061,7 +9069,7 @@ mod tests {
     stylesheet.minify(MinifyOptions {
       unused_symbols: vec!["bar"].iter().map(|s| String::from(*s)).collect(),
       ..MinifyOptions::default()
-    });
+    }).unwrap();
     let res = stylesheet.to_css(PrinterOptions::default()).unwrap();
     assert_eq!(res.code, expected);
 
@@ -9105,7 +9113,7 @@ mod tests {
     stylesheet.minify(MinifyOptions {
       unused_symbols: vec!["foo", "x"].iter().map(|s| String::from(*s)).collect(),
       ..MinifyOptions::default()
-    });
+    }).unwrap();
     let res = stylesheet.to_css(PrinterOptions {
       targets: Some(Browsers { chrome: Some(95 << 16), ..Browsers::default() }),
       ..PrinterOptions::default()
@@ -9199,5 +9207,514 @@ mod tests {
     @-ms-viewport {
       width: device-width;
     }"#, "@-ms-viewport{width:device-width}");
+  }
+
+  #[test]
+  fn test_custom_media() {
+    custom_media_test(
+      r#"
+      @custom-media --modern (color), (hover);
+
+      @media (--modern) and (width > 1024px) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      indoc! {r#"
+      @media ((color) or (hover)) and (width > 1024px) {
+        .a {
+          color: green;
+        }
+      }
+      "#}
+    );
+
+    custom_media_test(
+      r#"
+      @custom-media --color (color);
+
+      @media (--color) and (width > 1024px) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      indoc! {r#"
+      @media (color) and (width > 1024px) {
+        .a {
+          color: green;
+        }
+      }
+      "#}
+    );
+
+    custom_media_test(
+      r#"
+      @custom-media --a (color);
+      @custom-media --b (--a);
+
+      @media (--b) and (width > 1024px) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      indoc! {r#"
+      @media (color) and (width > 1024px) {
+        .a {
+          color: green;
+        }
+      }
+      "#}
+    );
+
+    custom_media_test(
+      r#"
+      @custom-media --not-color not (color);
+
+      @media not (--not-color) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      indoc! {r#"
+      @media (color) {
+        .a {
+          color: green;
+        }
+      }
+      "#}
+    );
+
+    custom_media_test(
+      r#"
+      @custom-media --color-print print and (color);
+
+      @media (--color-print) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      indoc! {r#"
+      @media print and (color) {
+        .a {
+          color: green;
+        }
+      }
+      "#}
+    );
+
+    custom_media_test(
+      r#"
+      @custom-media --color-print print and (color);
+
+      @media print and (--color-print) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      indoc! {r#"
+      @media print and (color) {
+        .a {
+          color: green;
+        }
+      }
+      "#}
+    );
+
+    custom_media_test(
+      r#"
+      @custom-media --not-color-print not print and (color);
+
+      @media not print and (--not-color-print) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      indoc! {r#"
+      @media not print and (color) {
+        .a {
+          color: green;
+        }
+      }
+      "#}
+    );
+
+    custom_media_test(
+      r#"
+      @custom-media --print print;
+
+      @media (--print) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      indoc! {r#"
+      @media print {
+        .a {
+          color: green;
+        }
+      }
+      "#}
+    );
+
+    custom_media_test(
+      r#"
+      @custom-media --print print;
+
+      @media not (--print) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      indoc! {r#"
+      @media not print {
+        .a {
+          color: green;
+        }
+      }
+      "#}
+    );
+
+    custom_media_test(
+      r#"
+      @custom-media --print not print;
+
+      @media not (--print) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      indoc! {r#"
+      @media print {
+        .a {
+          color: green;
+        }
+      }
+      "#}
+    );
+
+    custom_media_test(
+      r#"
+      @custom-media --print print;
+
+      @media ((--print)) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      indoc! {r#"
+      @media print {
+        .a {
+          color: green;
+        }
+      }
+      "#}
+    );
+
+    custom_media_test(
+      r#"
+      @custom-media --color (color);
+      @custom-media --print print;
+
+      @media (--print) and (--color) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      indoc! {r#"
+      @media print and (color) {
+        .a {
+          color: green;
+        }
+      }
+      "#}
+    );
+
+    custom_media_test(
+      r#"
+      @custom-media --color (color);
+      @custom-media --not-print not print;
+
+      @media (--not-print) and (--color) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      indoc! {r#"
+      @media not print and (color) {
+        .a {
+          color: green;
+        }
+      }
+      "#}
+    );
+
+    custom_media_test(
+      r#"
+      @custom-media --color (color);
+      @custom-media --screen screen;
+      @custom-media --print print;
+
+      @media (--print) and (--color), (--screen) and (--color) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      indoc! {r#"
+      @media print and (color), screen and (color) {
+        .a {
+          color: green;
+        }
+      }
+      "#}
+    );
+
+    custom_media_test(
+      r#"
+      @custom-media --color print and (color), print and (script);
+
+      @media (--color) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      indoc! {r#"
+      @media print and ((color) or (script)) {
+        .a {
+          color: green;
+        }
+      }
+      "#}
+    );
+
+    custom_media_test(
+      r#"
+      @custom-media --color (color);
+      @custom-media --not-color not all and (--color);
+
+      @media (--not-color) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      "\n"
+    );
+
+    custom_media_test(
+      r#"
+      @custom-media --color (color);
+
+      @media not all and (--color) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      "\n"
+    );
+
+    fn custom_media_error_test(source: &str, err: MinifyError) {
+      let mut stylesheet = StyleSheet::parse("test.css".into(), source, ParserOptions { custom_media: true, ..ParserOptions::default() }).unwrap();
+      let res = stylesheet.minify(MinifyOptions::default());
+      assert_eq!(res, Err(err))
+    }
+
+    custom_media_error_test(
+      r#"
+      @custom-media --color-print print and (color);
+
+      @media screen and (--color-print) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      MinifyError::UnsupportedCustomMediaBooleanLogic {
+        media_loc: SourceLocation {
+          line: 3,
+          column: 7
+        },
+        custom_media_loc: SourceLocation {
+          line: 1,
+          column: 7
+        }
+      }
+    );
+
+    custom_media_error_test(
+      r#"
+      @custom-media --color-print print and (color);
+
+      @media not print and (--color-print) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      MinifyError::UnsupportedCustomMediaBooleanLogic {
+        media_loc: SourceLocation {
+          line: 3,
+          column: 7
+        },
+        custom_media_loc: SourceLocation {
+          line: 1,
+          column: 7
+        }
+      }
+    );
+
+    custom_media_error_test(
+      r#"
+      @custom-media --color-print print and (color);
+      @custom-media --color-screen screen and (color);
+
+      @media (--color-print) or (--color-screen) {}
+      "#,
+      MinifyError::UnsupportedCustomMediaBooleanLogic {
+        media_loc: SourceLocation {
+          line: 4,
+          column: 7
+        },
+        custom_media_loc: SourceLocation {
+          line: 2,
+          column: 7
+        }
+      }
+    );
+
+    custom_media_error_test(
+      r#"
+      @custom-media --color-print print and (color);
+      @custom-media --color-screen screen and (color);
+
+      @media (--color-print) and (--color-screen) {}
+      "#,
+      MinifyError::UnsupportedCustomMediaBooleanLogic {
+        media_loc: SourceLocation {
+          line: 4,
+          column: 7
+        },
+        custom_media_loc: SourceLocation {
+          line: 2,
+          column: 7
+        }
+      }
+    );
+
+    custom_media_error_test(
+      r#"
+      @custom-media --screen screen;
+      @custom-media --print print;
+
+      @media (--print) and (--screen) {}
+      "#,
+      MinifyError::UnsupportedCustomMediaBooleanLogic {
+        media_loc: SourceLocation {
+          line: 4,
+          column: 7
+        },
+        custom_media_loc: SourceLocation {
+          line: 1,
+          column: 7
+        }
+      }
+    );
+
+    custom_media_error_test(
+      r#"
+      @custom-media --not-print not print and (color);
+      @custom-media --not-screen not screen and (color);
+
+      @media ((script) or ((--not-print) and (--not-screen))) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      MinifyError::UnsupportedCustomMediaBooleanLogic {
+        media_loc: SourceLocation {
+          line: 4,
+          column: 7
+        },
+        custom_media_loc: SourceLocation {
+          line: 2,
+          column: 7
+        }
+      }
+    );
+
+    custom_media_error_test(
+      r#"
+      @custom-media --color screen and (color), print and (color);
+
+      @media (--color) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      MinifyError::UnsupportedCustomMediaBooleanLogic {
+        media_loc: SourceLocation {
+          line: 3,
+          column: 7
+        },
+        custom_media_loc: SourceLocation {
+          line: 1,
+          column: 7
+        }
+      }
+    );
+
+    custom_media_error_test(
+      r#"
+      @media (--not-defined) {
+        .a {
+          color: green;
+        }
+      }
+      "#,
+      MinifyError::CustomMediaNotDefined {
+        name: "--not-defined".into(),
+        loc: SourceLocation {
+          line: 1,
+          column: 7
+        }
+      }
+    );
+
+    custom_media_error_test(
+      r#"
+      @custom-media --circular-mq-a (--circular-mq-b);
+      @custom-media --circular-mq-b (--circular-mq-a);
+
+      @media (--circular-mq-a) {
+        body {
+          order: 3;
+        }
+      }
+      "#,
+      MinifyError::CircularCustomMedia {
+        name: "--circular-mq-a".into(),
+        loc: SourceLocation {
+          line: 4,
+          column: 7
+        }
+      }
+    );
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9531,6 +9531,25 @@ mod tests {
       "\n"
     );
 
+    custom_media_test(
+      r#"
+      @media (--print) {
+        .a {
+          color: green;
+        }
+      }
+
+      @custom-media --print print;
+      "#,
+      indoc! {r#"
+      @media print {
+        .a {
+          color: green;
+        }
+      }
+      "#}
+    );
+
     fn custom_media_error_test(source: &str, err: MinifyError) {
       let mut stylesheet = StyleSheet::parse("test.css".into(), source, ParserOptions { custom_media: true, ..ParserOptions::default() }).unwrap();
       let res = stylesheet.minify(MinifyOptions {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,10 @@ mod tests {
 
   fn custom_media_test(source: &str, expected: &str) {
     let mut stylesheet = StyleSheet::parse("test.css".into(), source, ParserOptions { custom_media: true, ..ParserOptions::default() }).unwrap();
-    stylesheet.minify(MinifyOptions::default()).unwrap();
+    stylesheet.minify(MinifyOptions {
+      targets: Some(Browsers { chrome: Some(95 << 16), ..Browsers::default() }),
+      ..MinifyOptions::default()
+    }).unwrap();
     let res = stylesheet.to_css(PrinterOptions::default()).unwrap();
     assert_eq!(res.code, expected);
   }
@@ -9530,7 +9533,10 @@ mod tests {
 
     fn custom_media_error_test(source: &str, err: MinifyError) {
       let mut stylesheet = StyleSheet::parse("test.css".into(), source, ParserOptions { custom_media: true, ..ParserOptions::default() }).unwrap();
-      let res = stylesheet.minify(MinifyOptions::default());
+      let res = stylesheet.minify(MinifyOptions {
+        targets: Some(Browsers { chrome: Some(95 << 16), ..Browsers::default() }),
+        ..MinifyOptions::default()
+      });
       assert_eq!(res, Err(err))
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ pub fn main() -> Result<(), std::io::Error> {
 fn minify_css(cli_args: MinifyArgs) -> Result<(), std::io::Error> {
   let source = fs::read_to_string(&cli_args.input_file)?;
   let mut stylesheet = StyleSheet::parse(cli_args.input_file.to_string(), &source, ParserOptions::default()).unwrap();
-  stylesheet.minify(MinifyOptions::default());
+  stylesheet.minify(MinifyOptions::default()).unwrap();
   let res = stylesheet.to_css(PrinterOptions { minify: true, ..PrinterOptions::default()}).unwrap();
 
   if let Some(output_file) = cli_args.output_file {

--- a/src/media_query.rs
+++ b/src/media_query.rs
@@ -739,7 +739,8 @@ fn process_condition(
             res = Err(MinifyError::UnsupportedCustomMediaBooleanLogic {
               media_loc: loc,
               custom_media_loc: rule.loc
-            })
+            });
+            return None
           }
         }
         

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -130,6 +130,9 @@ impl<'a, 'i> AtRuleParser<'i> for TopLevelRuleParser<'a> {
         },
         "custom-media" if self.options.custom_media => {
           let name = input.expect_ident()?.as_ref().to_owned();
+          if !name.starts_with("--") {
+            return Err(input.new_unexpected_token_error(Token::Ident(name.into())));
+          }
           let media = MediaList::parse(input);
           return Ok(AtRulePrelude::CustomMedia(name, media))
         },

--- a/src/rules/custom_media.rs
+++ b/src/rules/custom_media.rs
@@ -1,0 +1,22 @@
+use cssparser::{SourceLocation, serialize_identifier};
+use crate::media_query::MediaList;
+use crate::traits::ToCss;
+use crate::printer::Printer;
+use crate::error::PrinterError;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct CustomMediaRule {
+  pub name: String,
+  pub query: MediaList,
+  pub loc: SourceLocation
+}
+
+impl ToCss for CustomMediaRule {
+  fn to_css<W>(&self, dest: &mut Printer<W>) -> Result<(), PrinterError> where W: std::fmt::Write {
+    dest.add_mapping(self.loc);
+    dest.write_str("@custom-media ")?;
+    serialize_identifier(&self.name, dest)?;
+    dest.write_char(' ')?;
+    self.query.to_css(dest)
+  }
+}

--- a/src/rules/document.rs
+++ b/src/rules/document.rs
@@ -2,7 +2,7 @@ use cssparser::SourceLocation;
 use crate::traits::ToCss;
 use crate::printer::Printer;
 use super::{CssRuleList, MinifyContext};
-use crate::error::PrinterError;
+use crate::error::{MinifyError, PrinterError};
 
 #[derive(Debug, PartialEq)]
 pub struct MozDocumentRule {
@@ -11,7 +11,7 @@ pub struct MozDocumentRule {
 }
 
 impl MozDocumentRule {
-  pub(crate) fn minify(&mut self, context: &mut MinifyContext) {
+  pub(crate) fn minify(&mut self, context: &mut MinifyContext) -> Result<(), MinifyError> {
     self.rules.minify(context, false)
   }
 }

--- a/src/rules/media.rs
+++ b/src/rules/media.rs
@@ -17,7 +17,7 @@ impl MediaRule {
   pub(crate) fn minify(&mut self, context: &mut MinifyContext, parent_is_unused: bool) -> Result<bool, MinifyError> {
     self.rules.minify(context, parent_is_unused)?;
 
-    if let Some(custom_media) = &mut context.custom_media {
+    if let Some(custom_media) = &context.custom_media {
       self.query.transform_custom_media(self.loc, custom_media)?;
     }
 

--- a/src/rules/media.rs
+++ b/src/rules/media.rs
@@ -4,7 +4,7 @@ use crate::traits::ToCss;
 use crate::printer::Printer;
 use super::{CssRuleList, MinifyContext};
 use crate::rules::{ToCssWithContext, StyleContext};
-use crate::error::PrinterError;
+use crate::error::{MinifyError, PrinterError};
 
 #[derive(Debug, PartialEq)]
 pub struct MediaRule {
@@ -14,8 +14,14 @@ pub struct MediaRule {
 }
 
 impl MediaRule {
-  pub(crate) fn minify(&mut self, context: &mut MinifyContext, parent_is_unused: bool) {
-    self.rules.minify(context, parent_is_unused);
+  pub(crate) fn minify(&mut self, context: &mut MinifyContext, parent_is_unused: bool) -> Result<bool, MinifyError> {
+    self.rules.minify(context, parent_is_unused)?;
+
+    if let Some(custom_media) = &mut context.custom_media {
+      self.query.transform_custom_media(self.loc, custom_media)?;
+    }
+
+    Ok(self.rules.0.is_empty() || self.query.never_matches())
   }
 }
 

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -141,8 +141,7 @@ impl CssRuleList {
           keyframe_rules.insert(keyframes.name.clone(), rules.len());
         },
         CssRule::CustomMedia(rule) => {
-          if let Some(custom_media) = &mut context.custom_media {
-            custom_media.insert(rule.name.clone(), rule.clone());
+          if context.custom_media.is_some() {
             continue;
           }
         },

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -140,7 +140,7 @@ impl CssRuleList {
           set_prefix!(keyframes);
           keyframe_rules.insert(keyframes.name.clone(), rules.len());
         },
-        CssRule::CustomMedia(rule) => {
+        CssRule::CustomMedia(_) => {
           if context.custom_media.is_some() {
             continue;
           }

--- a/src/rules/nesting.rs
+++ b/src/rules/nesting.rs
@@ -2,7 +2,7 @@ use cssparser::SourceLocation;
 use crate::printer::Printer;
 use super::style::StyleRule;
 use crate::rules::{ToCssWithContext, StyleContext};
-use crate::error::PrinterError;
+use crate::error::{PrinterError, MinifyError};
 use super::MinifyContext;
 
 #[derive(Debug, PartialEq)]
@@ -12,7 +12,7 @@ pub struct NestingRule {
 }
 
 impl NestingRule {
-  pub(crate) fn minify(&mut self, context: &mut MinifyContext, parent_is_unused: bool) -> bool {
+  pub(crate) fn minify(&mut self, context: &mut MinifyContext, parent_is_unused: bool) -> Result<bool, MinifyError> {
     self.style.minify(context, parent_is_unused)
   }
 }

--- a/src/rules/supports.rs
+++ b/src/rules/supports.rs
@@ -3,7 +3,7 @@ use crate::traits::{Parse, ToCss};
 use crate::printer::Printer;
 use super::{CssRuleList, MinifyContext};
 use crate::rules::{ToCssWithContext, StyleContext};
-use crate::error::{ParserError, PrinterError};
+use crate::error::{ParserError, MinifyError, PrinterError};
 
 #[derive(Debug, PartialEq)]
 pub struct SupportsRule {
@@ -13,7 +13,7 @@ pub struct SupportsRule {
 }
 
 impl SupportsRule {
-  pub(crate) fn minify(&mut self, context: &mut MinifyContext, parent_is_unused: bool) {
+  pub(crate) fn minify(&mut self, context: &mut MinifyContext, parent_is_unused: bool) -> Result<(), MinifyError> {
     self.rules.minify(context, parent_is_unused)
   }
 }

--- a/src/stylesheet.rs
+++ b/src/stylesheet.rs
@@ -11,6 +11,7 @@ use std::collections::{HashMap, HashSet};
 use crate::dependencies::Dependency;
 use crate::error::{ParserError, MinifyError, PrinterError};
 use crate::logical::LogicalProperties;
+use crate::compat::Feature;
 
 pub use crate::parser::ParserOptions;
 pub use crate::printer::PseudoClasses;
@@ -85,7 +86,7 @@ impl StyleSheet {
       important_handler: &mut important_handler,
       logical_properties: &mut logical_properties,
       unused_symbols: &options.unused_symbols,
-      custom_media: if self.options.custom_media {
+      custom_media: if self.options.custom_media && options.targets.is_some() && !Feature::CustomMediaQueries.is_compatible(options.targets.unwrap()) {
         Some(HashMap::new())
       } else {
         None


### PR DESCRIPTION
Fixes #49.

This adds basic support for the `@custom-media` rule, and referencing custom media queries in `@media` rules. It will error on complex boolean logic with media types (e.g. screen, print, etc.) because that is too hard to compile and seems unlikely to be used. See https://github.com/parcel-bundler/parcel-css/issues/49#issuecomment-1013897432. It will also error on circular media queries, and undefined references.

To do

- [x] Only compile when not supported by targets (like nesting)
- [x] Allow custom media queries to be defined after they are referenced (https://github.com/w3c/csswg-drafts/issues/6956)
- [ ] Figure out how to handle custom media rules defined in imported files?