### PR TITLE
Add sourcemap, nesting, and css-modules CLI flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,7 @@ dependencies = [
  "parcel_sourcemap",
  "retain_mut",
  "serde",
+ "serde_json",
  "smallvec",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,43 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "assert_cmd"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "assert_fs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf09bb72e00da477c2596865e8873227e2196d263cca35414048875dbbeea1be"
+dependencies = [
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,6 +61,17 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
 
 [[package]]
 name = "bumpalo"
@@ -51,9 +99,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.7"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e8611f9ae4e068fa3e56931fded356ff745e70987ff76924a6e0ab1c8ef2e3"
+checksum = "7a30c3bf9ff12dfe5dae53f0a96e0febcd18420d1c0e7fad77796d9d5c4b5375"
 dependencies = [
  "atty",
  "bitflags",
@@ -84,6 +132,16 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
+]
 
 [[package]]
 name = "cssparser"
@@ -132,6 +190,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +221,24 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "fastrand"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fnv"
@@ -185,6 +273,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,6 +318,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+dependencies = [
+ "crossbeam-utils",
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +352,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136"
 dependencies = [
  "unindent",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -268,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -283,9 +422,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
 
 [[package]]
 name = "log"
@@ -359,6 +498,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,6 +531,8 @@ dependencies = [
 name = "parcel_css"
 version = "1.0.0-alpha.13"
 dependencies = [
+ "assert_cmd",
+ "assert_fs",
  "bitflags",
  "clap",
  "cssparser",
@@ -380,6 +542,7 @@ dependencies = [
  "lazy_static",
  "parcel_selectors",
  "parcel_sourcemap",
+ "predicates",
  "retain_mut",
  "serde",
  "serde_json",
@@ -501,6 +664,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "predicates"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +813,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "retain_mut"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,6 +896,15 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "seahash"
@@ -718,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.74"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+checksum = "c059c05b48c5c0067d4b4b2b4f0732dd65feb52daf7e0ea09cd87e7dadc1af79"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -739,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
+checksum = "a86232ab60fa71287d7f2ddae4a7073f6b7aac33631c3015abb556f08c6d0a3e"
 
 [[package]]
 name = "smallvec"
@@ -763,13 +1006,27 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -782,10 +1039,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
+
+[[package]]
 name = "textwrap"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+
+[[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "unicode-xid"
@@ -812,6 +1084,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65dd7eed29412da847b0f78bcec0ac98588165988a8cfe41d4ea1d429f8ccfff"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,9 +1111,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -829,9 +1121,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -844,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -854,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -867,9 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ serde_json = "*"
 
 [dev-dependencies]
 indoc = "1.0.3"
+assert_cmd = "2.0"
+assert_fs = "1.0"
+predicates = "2.1"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ data-encoding = "2.3.2"
 lazy_static = "1.4.0"
 clap = { version = "3.0.6", features = ["derive"] }
 retain_mut = "0.1.5"
+serde_json = "*"
 
 [dev-dependencies]
 indoc = "1.0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,9 +13,12 @@ struct CliArgs {
   /// The destination file for the output
   #[clap(short, long)]
   output_file: Option<String>,
-  /// Enable CSS nesting in output
+  /// Enable nesting in output
   #[clap(short, long)]
   nesting: bool,
+  /// Enable CSS modules in output
+  #[clap(short, long)]
+  css_modules: bool,
 }
 
 pub fn main() -> Result<(), std::io::Error> {
@@ -24,6 +27,7 @@ pub fn main() -> Result<(), std::io::Error> {
 
   let mut stylesheet = StyleSheet::parse(cli_args.input_file.to_string(), &source, ParserOptions {
     nesting: cli_args.nesting,
+    css_modules: cli_args.css_modules,
     ..ParserOptions::default()
   }).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,20 +5,21 @@ use parcel_css::stylesheet::{MinifyOptions, ParserOptions, PrinterOptions, Style
 #[derive(Parser, Debug)]
 #[clap(author, about, long_about = None)]
 struct CliArgs {
-  /// The CSS file to minify
+  /// Target CSS file
   input_file: String,
+  /// Destination file for the output
+  #[clap(short, long)]
+  output_file: Option<String>,
   /// Minify the output 
   #[clap(short, long)]
   minify: bool,
-  /// The destination file for the output
-  #[clap(short, long)]
-  output_file: Option<String>,
-  /// Enable nesting in output
+  /// Enable parsing CSS nesting
   #[clap(short, long)]
   nesting: bool,
   /// Enable CSS modules in output
   #[clap(short, long, group = "css_modules")]
   css_modules: bool,
+  /// Default: <output_file>.json
   #[clap(long, requires = "css_modules")]
   css_modules_output_file: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,22 +3,29 @@ use clap::Parser;
 use parcel_css::stylesheet::{MinifyOptions, ParserOptions, PrinterOptions, StyleSheet};
 
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, about, long_about = None)]
 struct CliArgs {
   /// The CSS file to minify
   input_file: String,
   /// Minify the output 
   #[clap(short, long)]
   minify: bool,
-    /// The destination file for the output
+  /// The destination file for the output
   #[clap(short, long)]
   output_file: Option<String>,
+  /// Enable CSS nesting in output
+  #[clap(short, long)]
+  nesting: bool,
 }
 
 pub fn main() -> Result<(), std::io::Error> {
   let cli_args = CliArgs::parse();
   let source = fs::read_to_string(&cli_args.input_file)?;
-  let mut stylesheet = StyleSheet::parse(cli_args.input_file.to_string(), &source, ParserOptions::default()).unwrap();
+
+  let mut stylesheet = StyleSheet::parse(cli_args.input_file.to_string(), &source, ParserOptions {
+    nesting: cli_args.nesting,
+    ..ParserOptions::default()
+  }).unwrap();
 
   if cli_args.minify {
     stylesheet.minify(MinifyOptions::default()).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,10 @@ struct CliArgs {
   /// Default: <output_file>.json
   #[clap(long, requires = "css_modules")]
   css_modules_output_file: Option<String>,
+  // cli integration tests
+  // --targets
+  // --sourcemap
+  // multiple input files
 }
 
 pub fn main() -> Result<(), std::io::Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,9 @@ pub fn main() -> Result<(), std::io::Error> {
   let cli_args = CliArgs::parse();
   let source = fs::read_to_string(&cli_args.input_file)?;
 
-  let mut stylesheet = StyleSheet::parse(cli_args.input_file.to_string(), &source, ParserOptions {
+  let filename = path::Path::new(&cli_args.input_file)
+    .file_name().unwrap().to_str().unwrap().into();
+  let mut stylesheet = StyleSheet::parse(filename, &source, ParserOptions {
     nesting: cli_args.nesting,
     css_modules: cli_args.css_modules,
     ..ParserOptions::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,85 +1,94 @@
-use std::{fs, path, io, ffi};
 use clap::Parser;
 use parcel_css::stylesheet::{MinifyOptions, ParserOptions, PrinterOptions, StyleSheet};
+use std::{ffi, fs, io, path};
 
 #[derive(Parser, Debug)]
 #[clap(author, about, long_about = None)]
 struct CliArgs {
-  /// Target CSS file
-  input_file: String,
-  /// Destination file for the output
-  #[clap(short, long)]
-  output_file: Option<String>,
-  /// Minify the output 
-  #[clap(short, long)]
-  minify: bool,
-  /// Enable parsing CSS nesting
-  #[clap(short, long)]
-  nesting: bool,
-  /// Enable CSS modules in output
-  #[clap(short, long, group = "css_modules")]
-  css_modules: bool,
-  /// Default: <output_file>.json
-  #[clap(long, requires = "css_modules")]
-  css_modules_output_file: Option<String>,
-  // cli integration tests
-  // --targets
-  // --sourcemap
-  // multiple input files
+    /// Target CSS file
+    input_file: String,
+    /// Destination file for the output
+    #[clap(short, long)]
+    output_file: Option<String>,
+    /// Minify the output
+    #[clap(short, long)]
+    minify: bool,
+    /// Enable parsing CSS nesting
+    #[clap(short, long)]
+    nesting: bool,
+    /// Enable CSS modules in output
+    #[clap(short, long, group = "css_modules")]
+    css_modules: bool,
+    /// Default: <output_file>.json
+    #[clap(long, requires = "css_modules")]
+    css_modules_output_file: Option<String>,
 }
 
 pub fn main() -> Result<(), std::io::Error> {
-  let cli_args = CliArgs::parse();
-  let source = fs::read_to_string(&cli_args.input_file)?;
+    let cli_args = CliArgs::parse();
+    let source = fs::read_to_string(&cli_args.input_file)?;
 
-  let filename = path::Path::new(&cli_args.input_file)
-    .file_name().unwrap().to_str().unwrap().into();
-  let mut stylesheet = StyleSheet::parse(filename, &source, ParserOptions {
-    nesting: cli_args.nesting,
-    css_modules: cli_args.css_modules,
-    ..ParserOptions::default()
-  }).unwrap();
+    let filename = path::Path::new(&cli_args.input_file)
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .into();
+    let mut stylesheet = StyleSheet::parse(
+        filename,
+        &source,
+        ParserOptions {
+            nesting: cli_args.nesting,
+            css_modules: cli_args.css_modules,
+            ..ParserOptions::default()
+        },
+    )
+    .unwrap();
 
-  if cli_args.minify {
-    stylesheet.minify(MinifyOptions::default()).unwrap();
-  }
-
-  let res = stylesheet.to_css(PrinterOptions { 
-    minify: cli_args.minify, 
-    ..PrinterOptions::default()
-  }).unwrap();
-
-  if let Some(output_file) = &cli_args.output_file {
-    fs::write(output_file, res.code.as_bytes())?;
-
-    if cli_args.css_modules {
-      let css_modules_filename = cli_args.css_modules_output_file.unwrap_or(infer_css_modules_filename(cli_args.output_file)?);
-      if let Some(exports) = res.exports {
-        let css_modules_json = serde_json::to_string(&exports)?;
-        fs::write(css_modules_filename, css_modules_json)?;
-      }
+    if cli_args.minify {
+        stylesheet.minify(MinifyOptions::default()).unwrap();
     }
-  } else {
-    println!("{}", res.code);
-    if cli_args.css_modules {
-      let css_modules_json = serde_json::to_string(&res.exports)?;
-      println!("{}", css_modules_json);
-    }
-  }
 
-  Ok(())
+    let res = stylesheet
+        .to_css(PrinterOptions {
+            minify: cli_args.minify,
+            ..PrinterOptions::default()
+        })
+        .unwrap();
+
+    if let Some(output_file) = &cli_args.output_file {
+        fs::write(output_file, res.code.as_bytes())?;
+
+        if cli_args.css_modules {
+            let css_modules_filename = cli_args
+                .css_modules_output_file
+                .unwrap_or(infer_css_modules_filename(cli_args.output_file)?);
+            if let Some(exports) = res.exports {
+                let css_modules_json = serde_json::to_string(&exports)?;
+                fs::write(css_modules_filename, css_modules_json)?;
+            }
+        }
+    } else {
+        println!("{}", res.code);
+        if cli_args.css_modules {
+            let css_modules_json = serde_json::to_string(&res.exports)?;
+            println!("{}", css_modules_json);
+        }
+    }
+
+    Ok(())
 }
 
 fn infer_css_modules_filename(output_file: Option<String>) -> Result<String, std::io::Error> {
-  if let Some(file) = output_file {
-    let path = path::Path::new(&file);
-    if path.extension() == Some(ffi::OsStr::new("json")) {
-      Err(io::Error::new(io::ErrorKind::Other, "Cannot infer a css modules json filename, since the output file extension is '.json'"))
+    if let Some(file) = output_file {
+        let path = path::Path::new(&file);
+        if path.extension() == Some(ffi::OsStr::new("json")) {
+            Err(io::Error::new(io::ErrorKind::Other, "Cannot infer a css modules json filename, since the output file extension is '.json'"))
+        } else {
+            // unwrap: the filename option is a String from clap, so is valid utf-8
+            Ok(path.with_extension("json").to_str().unwrap().into())
+        }
     } else {
-      // unwrap: the filename option is a String from clap, so is valid utf-8
-      Ok(path.with_extension("json").to_str().unwrap().into())
+        Ok("styles.json".into())
     }
-  } else {
-    Ok("styles.json".into())
-  }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,11 +40,37 @@ pub fn main() -> Result<(), std::io::Error> {
     ..PrinterOptions::default()
   }).unwrap();
 
-  if let Some(output_file) = cli_args.output_file {
+  // if options.css_modules
+  // write a css modules exports file, as json
+  // or print the css modules to the command line
+  // question: how to specify the output location for the css modules file?
+  // heuristics: if there's an output file has a postfix other than .json, use its prefix plus .json
+  // if it ends in .json... exit with an error, informing the user to use the option
+  // if we're printing to the command line, then...
+  // the css should get shown, and then the css modules file? Or, need to use an output file in
+  // order to use css modules?
+  if let Some(output_file) = &cli_args.output_file {
     fs::write(output_file, res.code.as_bytes())?;
+
+    if cli_args.css_modules {
+      let css_modules_filename = infer_css_modules_filename(cli_args.output_file);
+      if let Some(exports) = res.exports {
+        let css_modules_json = serde_json::to_string(&exports)?;
+        fs::write(css_modules_filename, css_modules_json)?;
+      }
+    }
   } else {
     println!("{}", res.code);
+    if cli_args.css_modules {
+      let css_modules_json = serde_json::to_string(&res.exports)?;
+      println!("{}", css_modules_json);
+    }
   }
 
   Ok(())
+}
+
+fn infer_css_modules_filename(_output_file: Option<String>) -> String {
+  // TODO ... actually infer
+  "styles.json".into()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,36 +1,33 @@
 use std::fs;
-use clap::{Args, Parser};
+use clap::Parser;
 use parcel_css::stylesheet::{MinifyOptions, ParserOptions, PrinterOptions, StyleSheet};
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
-enum Cli {
-  /// Minify a given CSS file
-  Minify(MinifyArgs),
-}
-
-#[derive(Args, Debug)]
-struct MinifyArgs {
+struct CliArgs {
   /// The CSS file to minify
   input_file: String,
-  /// The name of the output file
+  /// Minify the output 
+  #[clap(short, long)]
+  minify: bool,
+    /// The destination file for the output
   #[clap(short, long)]
   output_file: Option<String>,
 }
 
 pub fn main() -> Result<(), std::io::Error> {
-  match Cli::parse() {
-    Cli::Minify(cli_args) => {
-      minify_css(cli_args)
-    }
-  }
-}
-
-fn minify_css(cli_args: MinifyArgs) -> Result<(), std::io::Error> {
+  let cli_args = CliArgs::parse();
   let source = fs::read_to_string(&cli_args.input_file)?;
   let mut stylesheet = StyleSheet::parse(cli_args.input_file.to_string(), &source, ParserOptions::default()).unwrap();
-  stylesheet.minify(MinifyOptions::default()).unwrap();
-  let res = stylesheet.to_css(PrinterOptions { minify: true, ..PrinterOptions::default()}).unwrap();
+
+  if cli_args.minify {
+    stylesheet.minify(MinifyOptions::default()).unwrap();
+  }
+
+  let res = stylesheet.to_css(PrinterOptions { 
+    minify: cli_args.minify, 
+    ..PrinterOptions::default()
+  }).unwrap();
 
   if let Some(output_file) = cli_args.output_file {
     fs::write(output_file, res.code.as_bytes())?;

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -1,31 +1,69 @@
 use assert_cmd::prelude::*;
-use predicates::prelude::*;
-use std::process::Command;
-use std::collections::HashMap;
-use assert_fs::prelude::*;
 use assert_fs::fixture::FixtureError;
+use assert_fs::prelude::*;
 use indoc::indoc;
 use parcel_css::css_modules::CssModuleExport;
+use predicates::prelude::*;
+use std::collections::HashMap;
+use std::process::Command;
 
 fn test_file() -> Result<assert_fs::NamedTempFile, FixtureError> {
     let file = assert_fs::NamedTempFile::new("test.css")?;
-    file.write_str(r#"
+    file.write_str(
+        r#"
       .foo {
         border: none;
       }
-    "#)?;
+    "#,
+    )?;
     Ok(file)
 }
 
 fn css_module_test_vals() -> (String, String, String) {
     let exports: HashMap<&str, CssModuleExport> = HashMap::from([
-        ("fade", CssModuleExport { name: "fade_EgL3uq".into(), composes: vec![], is_referenced: false}),
-        ("foo", CssModuleExport { name: "foo_EgL3uq".into(), composes: vec![], is_referenced: false}),
-        ("circles", CssModuleExport { name: "circles_EgL3uq".into(), composes: vec![], is_referenced: true}),
-        ("id", CssModuleExport { name: "id_EgL3uq".into(), composes: vec![], is_referenced: false}),
-        ("test", CssModuleExport { name: "test_EgL3uq".into(), composes: vec![], is_referenced: true }),
-        ]);
-    (r#"
+        (
+            "fade",
+            CssModuleExport {
+                name: "fade_EgL3uq".into(),
+                composes: vec![],
+                is_referenced: false,
+            },
+        ),
+        (
+            "foo",
+            CssModuleExport {
+                name: "foo_EgL3uq".into(),
+                composes: vec![],
+                is_referenced: false,
+            },
+        ),
+        (
+            "circles",
+            CssModuleExport {
+                name: "circles_EgL3uq".into(),
+                composes: vec![],
+                is_referenced: true,
+            },
+        ),
+        (
+            "id",
+            CssModuleExport {
+                name: "id_EgL3uq".into(),
+                composes: vec![],
+                is_referenced: false,
+            },
+        ),
+        (
+            "test",
+            CssModuleExport {
+                name: "test_EgL3uq".into(),
+                composes: vec![],
+                is_referenced: true,
+            },
+        ),
+    ]);
+    (
+        r#"
       .foo {
         color: red;
       }
@@ -51,7 +89,9 @@ fn css_module_test_vals() -> (String, String, String) {
         from { opacity: 0 }
         to { opacity: 1 }
       }
-    "#.into(), indoc!{r#"
+    "#
+        .into(),
+        indoc! {r#"
       .foo_EgL3uq {
         color: red;
       }
@@ -87,20 +127,22 @@ fn css_module_test_vals() -> (String, String, String) {
           opacity: 1;
         }
       }
-    "#}.into(),
-    serde_json::to_string(&exports).unwrap()
+    "#}
+        .into(),
+        serde_json::to_string(&exports).unwrap(),
     )
 }
 
 #[test]
 fn valid_input_file() -> Result<(), Box<dyn std::error::Error>> {
     let file = assert_fs::NamedTempFile::new("test.css")?;
-    file.write_str(r#"
+    file.write_str(
+        r#"
       .foo {
         border: none;
       }
-    "#)?;
-
+    "#,
+    )?;
 
     let mut cmd = Command::cargo_bin("parcel_css")?;
     cmd.arg(file.path());
@@ -117,9 +159,9 @@ fn valid_input_file() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn no_input_file() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("parcel_css")?;
-    cmd.assert()
-        .failure()
-        .stderr(predicate::str::contains("The following required arguments were not provided:\n    <INPUT_FILE>"));
+    cmd.assert().failure().stderr(predicate::str::contains(
+        "The following required arguments were not provided:\n    <INPUT_FILE>",
+    ));
 
     Ok(())
 }
@@ -129,11 +171,9 @@ fn empty_input_file() -> Result<(), Box<dyn std::error::Error>> {
     let file = assert_fs::NamedTempFile::new("test.css")?;
     file.write_str("")?;
 
-
     let mut cmd = Command::cargo_bin("parcel_css")?;
     cmd.arg(file.path());
-    cmd.assert()
-        .success();
+    cmd.assert().success();
 
     Ok(())
 }
@@ -169,22 +209,24 @@ fn minify_option() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 // nesting doesn't do anything with the default targets. until cli supports more targets, this option is a noop
-#[ignore] 
+#[ignore]
 fn nesting_option() -> Result<(), Box<dyn std::error::Error>> {
     let infile = assert_fs::NamedTempFile::new("test.css")?;
-    infile.write_str(r#"
+    infile.write_str(
+        r#"
         .foo {
           color: blue;
           & > .bar { color: red; }
         }
-      "#)?;
-      
+      "#,
+    )?;
+
     let mut cmd = Command::cargo_bin("parcel_css")?;
     cmd.arg(infile.path());
     cmd.arg("--nesting");
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains(indoc!{r#"
+        .stdout(predicate::str::contains(indoc! {r#"
         .foo {
           color: #00f;
         }
@@ -193,7 +235,6 @@ fn nesting_option() -> Result<(), Box<dyn std::error::Error>> {
           color: red;
         }
       "#}));
-
 
     Ok(())
 }
@@ -213,7 +254,7 @@ fn css_modules_stdout() -> Result<(), Box<dyn std::error::Error>> {
     let assert = cmd.assert();
     let output = String::from_utf8(assert.get_output().stdout.clone())?;
     let module_json_line = output.lines().next_back().unwrap();
-    let expected: serde_json::Value = serde_json::from_str(&exports)?; 
+    let expected: serde_json::Value = serde_json::from_str(&exports)?;
     let actual: serde_json::Value = serde_json::from_str(&module_json_line)?;
     assert_eq!(expected, actual);
 
@@ -235,10 +276,10 @@ fn css_modules_infer_output_file() -> Result<(), Box<dyn std::error::Error>> {
         .success()
         .stdout(predicate::str::contains(output));
 
-    let expected: serde_json::Value = serde_json::from_str(&exports)?; 
-    let actual: serde_json::Value = serde_json::from_str(
-        &std::fs::read_to_string(outfile.path().with_extension("json"))?
-    )?;
+    let expected: serde_json::Value = serde_json::from_str(&exports)?;
+    let actual: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(
+        outfile.path().with_extension("json"),
+    )?)?;
     assert_eq!(expected, actual);
 
     Ok(())
@@ -255,13 +296,13 @@ fn css_modules_output_target_option() -> Result<(), Box<dyn std::error::Error>> 
     cmd.arg(infile.path());
     cmd.arg("-o").arg(outfile.path());
     cmd.arg("--css-modules");
-    cmd.arg("--css-modules-output-file").arg(modules_file.path());
+    cmd.arg("--css-modules-output-file")
+        .arg(modules_file.path());
     cmd.assert().success();
 
-    let expected: serde_json::Value = serde_json::from_str(&exports)?; 
-    let actual: serde_json::Value = serde_json::from_str(
-        &std::fs::read_to_string(modules_file.path())?
-    )?;
+    let expected: serde_json::Value = serde_json::from_str(&exports)?;
+    let actual: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(modules_file.path())?)?;
     assert_eq!(expected, actual);
 
     Ok(())

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -1,8 +1,96 @@
 use assert_cmd::prelude::*;
 use predicates::prelude::*;
 use std::process::Command;
+use std::collections::HashMap;
 use assert_fs::prelude::*;
+use assert_fs::fixture::FixtureError;
 use indoc::indoc;
+use parcel_css::css_modules::CssModuleExport;
+
+fn test_file() -> Result<assert_fs::NamedTempFile, FixtureError> {
+    let file = assert_fs::NamedTempFile::new("test.css")?;
+    file.write_str(r#"
+      .foo {
+        border: none;
+      }
+    "#)?;
+    Ok(file)
+}
+
+fn css_module_test_vals() -> (String, String, String) {
+    let exports: HashMap<&str, CssModuleExport> = HashMap::from([
+        ("fade", CssModuleExport { name: "fade_EgL3uq".into(), composes: vec![], is_referenced: false}),
+        ("foo", CssModuleExport { name: "foo_EgL3uq".into(), composes: vec![], is_referenced: false}),
+        ("circles", CssModuleExport { name: "circles_EgL3uq".into(), composes: vec![], is_referenced: true}),
+        ("id", CssModuleExport { name: "id_EgL3uq".into(), composes: vec![], is_referenced: false}),
+        ("test", CssModuleExport { name: "test_EgL3uq".into(), composes: vec![], is_referenced: true }),
+        ]);
+    (r#"
+      .foo {
+        color: red;
+      }
+      
+      #id {
+        animation: 2s test;
+      }
+
+      @keyframes test {
+        from { color: red }
+        to { color: yellow }
+      }
+
+      @counter-style circles {
+        symbols: Ⓐ Ⓑ Ⓒ;
+      }
+
+      ul {
+        list-style: circles;
+      }
+
+      @keyframes fade {
+        from { opacity: 0 }
+        to { opacity: 1 }
+      }
+    "#.into(), indoc!{r#"
+      .foo_EgL3uq {
+        color: red;
+      }
+
+      #id_EgL3uq {
+        animation: test_EgL3uq 2s;
+      }
+
+      @keyframes test_EgL3uq {
+        from {
+          color: red;
+        }
+
+        to {
+          color: #ff0;
+        }
+      }
+
+      @counter-style circles_EgL3uq {
+        symbols: Ⓐ Ⓑ Ⓒ;
+      }
+
+      ul {
+        list-style: circles_EgL3uq;
+      }
+
+      @keyframes fade_EgL3uq {
+        from {
+          opacity: 0;
+        }
+
+        to {
+          opacity: 1;
+        }
+      }
+    "#}.into(),
+    serde_json::to_string(&exports).unwrap()
+    )
+}
 
 #[test]
 fn valid_input_file() -> Result<(), Box<dyn std::error::Error>> {
@@ -28,40 +116,153 @@ fn valid_input_file() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn no_input_file() -> Result<(), Box<dyn std::error::Error>> {
-    panic!("todo test");
+    let mut cmd = Command::cargo_bin("parcel_css")?;
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("The following required arguments were not provided:\n    <INPUT_FILE>"));
+
+    Ok(())
 }
 
 #[test]
 fn empty_input_file() -> Result<(), Box<dyn std::error::Error>> {
-    panic!("todo test");
+    let file = assert_fs::NamedTempFile::new("test.css")?;
+    file.write_str("")?;
+
+
+    let mut cmd = Command::cargo_bin("parcel_css")?;
+    cmd.arg(file.path());
+    cmd.assert()
+        .success();
+
+    Ok(())
 }
 
 #[test]
 fn output_file_option() -> Result<(), Box<dyn std::error::Error>> {
-    panic!("todo test");
+    let infile = test_file()?;
+    let outfile = assert_fs::NamedTempFile::new("test.out")?;
+    let mut cmd = Command::cargo_bin("parcel_css")?;
+    cmd.arg(infile.path());
+    cmd.arg("--output-file").arg(outfile.path());
+    cmd.assert().success();
+    outfile.assert(predicate::str::contains(indoc! {r#"
+        .foo {
+          border: none;
+        }"#}));
+
+    Ok(())
 }
 
 #[test]
 fn minify_option() -> Result<(), Box<dyn std::error::Error>> {
-    panic!("todo test");
+    let infile = test_file()?;
+    let mut cmd = Command::cargo_bin("parcel_css")?;
+    cmd.arg(infile.path());
+    cmd.arg("--minify");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(indoc! {r#".foo{border:0}"#}));
+
+    Ok(())
 }
 
 #[test]
+// nesting doesn't do anything with the default targets. until cli supports more targets, this option is a noop
+#[ignore] 
 fn nesting_option() -> Result<(), Box<dyn std::error::Error>> {
-    panic!("todo test");
+    let infile = assert_fs::NamedTempFile::new("test.css")?;
+    infile.write_str(r#"
+        .foo {
+          color: blue;
+          & > .bar { color: red; }
+        }
+      "#)?;
+      
+    let mut cmd = Command::cargo_bin("parcel_css")?;
+    cmd.arg(infile.path());
+    cmd.arg("--nesting");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(indoc!{r#"
+        .foo {
+          color: #00f;
+        }
+
+        .foo > .bar {
+          color: red;
+        }
+      "#}));
+
+
+    Ok(())
 }
 
 #[test]
 fn css_modules_stdout() -> Result<(), Box<dyn std::error::Error>> {
-    panic!("todo test");
+    let (input, output, exports) = css_module_test_vals();
+    let infile = assert_fs::NamedTempFile::new("test.css")?;
+    infile.write_str(&input)?;
+    let mut cmd = Command::cargo_bin("parcel_css")?;
+    cmd.arg(infile.path());
+    cmd.arg("--css-modules");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(output));
+
+    let assert = cmd.assert();
+    let output = String::from_utf8(assert.get_output().stdout.clone())?;
+    let module_json_line = output.lines().next_back().unwrap();
+    let expected: serde_json::Value = serde_json::from_str(&exports)?; 
+    let actual: serde_json::Value = serde_json::from_str(&module_json_line)?;
+    assert_eq!(expected, actual);
+
+    Ok(())
 }
 
 #[test]
+#[ignore]
 fn css_modules_infer_output_file() -> Result<(), Box<dyn std::error::Error>> {
-    panic!("todo test");
+    let (input, output, exports) = css_module_test_vals();
+    let infile = assert_fs::NamedTempFile::new("test.css")?;
+    let outfile = assert_fs::NamedTempFile::new("out.css")?;
+    infile.write_str(&input)?;
+    let mut cmd = Command::cargo_bin("parcel_css")?;
+    cmd.arg(infile.path());
+    cmd.arg("--css-modules");
+    cmd.arg("-o").arg(outfile.path());
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(output));
+
+    let expected: serde_json::Value = serde_json::from_str(&exports)?; 
+    let actual: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(outfile.path().with_extension("json"))?
+    )?;
+    assert_eq!(expected, actual);
+
+    Ok(())
 }
 
 #[test]
 fn css_modules_output_target_option() -> Result<(), Box<dyn std::error::Error>> {
-    panic!("todo test");
+    let (input, output, exports) = css_module_test_vals();
+    let infile = assert_fs::NamedTempFile::new("test.css")?;
+    let outfile = assert_fs::NamedTempFile::new("out.css")?;
+    let modules_file = assert_fs::NamedTempFile::new("module.json")?;
+    infile.write_str(&input)?;
+    let mut cmd = Command::cargo_bin("parcel_css")?;
+    cmd.arg(infile.path());
+    cmd.arg("-o").arg(outfile.path());
+    cmd.arg("--css-modules");
+    cmd.arg("--css-modules-output-file").arg(modules_file.path());
+    cmd.assert().success();
+
+    let expected: serde_json::Value = serde_json::from_str(&exports)?; 
+    let actual: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(modules_file.path())?
+    )?;
+    assert_eq!(expected, actual);
+
+    Ok(())
 }

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -1,0 +1,67 @@
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use std::process::Command;
+use assert_fs::prelude::*;
+use indoc::indoc;
+
+#[test]
+fn valid_input_file() -> Result<(), Box<dyn std::error::Error>> {
+    let file = assert_fs::NamedTempFile::new("test.css")?;
+    file.write_str(r#"
+      .foo {
+        border: none;
+      }
+    "#)?;
+
+
+    let mut cmd = Command::cargo_bin("parcel_css")?;
+    cmd.arg(file.path());
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(indoc! {r#"
+        .foo {
+          border: none;
+        }"#}));
+
+    Ok(())
+}
+
+#[test]
+fn no_input_file() -> Result<(), Box<dyn std::error::Error>> {
+    panic!("todo test");
+}
+
+#[test]
+fn empty_input_file() -> Result<(), Box<dyn std::error::Error>> {
+    panic!("todo test");
+}
+
+#[test]
+fn output_file_option() -> Result<(), Box<dyn std::error::Error>> {
+    panic!("todo test");
+}
+
+#[test]
+fn minify_option() -> Result<(), Box<dyn std::error::Error>> {
+    panic!("todo test");
+}
+
+#[test]
+fn nesting_option() -> Result<(), Box<dyn std::error::Error>> {
+    panic!("todo test");
+}
+
+#[test]
+fn css_modules_stdout() -> Result<(), Box<dyn std::error::Error>> {
+    panic!("todo test");
+}
+
+#[test]
+fn css_modules_infer_output_file() -> Result<(), Box<dyn std::error::Error>> {
+    panic!("todo test");
+}
+
+#[test]
+fn css_modules_output_target_option() -> Result<(), Box<dyn std::error::Error>> {
+    panic!("todo test");
+}


### PR DESCRIPTION
Address parts of #52, but not `--targets` or transforming multiple files.

* makes `--minify` a boolean option, instead of a subcommand
* instead of  `--input-file` option as part of the minify subcommand, input file is now a required positional arg
* moves `--output-file` from subcommand to the top level
* adds `--nesting` boolean option, to enable nesting
* adds `--css-modules` and `--css-modules-output-file` options
* adds `--sourcemap` option
* adds integration tests in rust for the CLI in `tests/cli_integration_tests.rs`

CSS Modules and sourcemap options make what seem to me like decent default choices for where to send their output. 

* Sourcemap requires an output file, since it doesn't make sense to have a sourcemap without a file...
* if there's an output file `out.css`, then the map is written to `out.css.map`
* css modules allows specifying a path for the json output, or writes to `out.json` if there's an output file named `out.css`

I'd be glad for any feedback, and happy to carve it into smaller chunks, in case this PR is too large.

