### PR TITLE
Add "cli" Cargo feature to make binary-only dependencies optional.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,14 @@ edition = "2018"
 keywords = [ "CSS", "minifier", "Parcel" ]
 repository = "https://github.com/parcel-bundler/parcel-css"
 
-[features]
-default = ["grid"]
-grid = []
+[[bin]]
+name = "parcel_css"
+path = "src/main.rs"
+required-features = ["cli"]
 
 [lib]
+name = "parcel_css"
+path = "src/lib.rs"
 crate-type = ["rlib"]
 
 [dependencies]
@@ -31,7 +34,7 @@ bitflags = "1.3.2"
 parcel_sourcemap = "2.0.0"
 data-encoding = "2.3.2"
 lazy_static = "1.4.0"
-clap = { version = "3.0.6", features = ["derive"] }
+clap = { version = "3.0.6", features = ["derive"], optional = true }
 retain_mut = "0.1.5"
 serde_json = "*"
 pathdiff = "0.2.1"
@@ -41,6 +44,16 @@ indoc = "1.0.3"
 assert_cmd = "2.0"
 assert_fs = "1.0"
 predicates = "2.1"
+
+[features]
+default = ["cli", "grid"]
+cli = ["clap"]
+grid = []
+
+[[test]]
+name = "cli_integration_tests"
+path = "tests/cli_integration_tests.rs"
+required-features = ["cli"]
 
 [profile.release]
 lto = true


### PR DESCRIPTION
I think it would be beneficial for library use cases to make the binary-only dependencies (i.e. `clap`) optional. This PR adds a (default) "cli" feature to that end.

Thanks for the excellent project!