### PR TITLE
Merge important declarations of adjacent rules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3849,6 +3849,19 @@ mod tests {
     "#});
     test(r#"
       .foo {
+        color: red;
+      }
+      .foo {
+        background: green !important;
+      }
+    "#, indoc! {r#"
+      .foo {
+        color: red;
+        background: green !important;
+      }
+    "#});
+    test(r#"
+      .foo {
         background: red;
       }
       .foo {

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -185,6 +185,7 @@ impl<'i> CssRuleList<'i> {
             // Merge declarations if the selectors are equivalent, and both are compatible with all targets.
             if style.selectors == last_style_rule.selectors && style.is_compatible(*context.targets) && last_style_rule.is_compatible(*context.targets) && style.rules.0.is_empty() && last_style_rule.rules.0.is_empty() {
               last_style_rule.declarations.declarations.extend(style.declarations.declarations.drain(..));
+              last_style_rule.declarations.important_declarations.extend(style.declarations.important_declarations.drain(..));
               last_style_rule.declarations.minify(context.handler, context.important_handler, context.logical_properties);
               continue
             } else if style.declarations == last_style_rule.declarations && style.rules.0.is_empty() && last_style_rule.rules.0.is_empty() {


### PR DESCRIPTION
Hi there! 👋🏽 

I was exploring `@parcel/css` and noticed `!important` declarations were excluded from the output - [playground link](https://parcel-css.vercel.app/#%7B%22minify%22%3Afalse%2C%22nesting%22%3Atrue%2C%22customMedia%22%3Atrue%2C%22cssModules%22%3Afalse%2C%22analyzeDependencies%22%3Afalse%2C%22targets%22%3A%7B%22chrome%22%3A6225920%7D%2C%22source%22%3A%22.foo%20%7B%5Cn%20%20color%3A%20red%3B%5Cn%7D%5Cn.foo%20%7B%5Cn%20%20background%3A%20green%20!important%3B%5Cn%7D%22%2C%22unusedSymbols%22%3A%5B%5D%7D).

I don't know if it's by default so I took some time to dig into the source code and change this behaviour. If it's by default, please close this PR.
If it's not, let me know if I missed something or you have any suggestions.

PS: I was wondering if we need a similar check as this [else if](https://github.com/parcel-bundler/parcel-css/blob/master/src/rules/mod.rs#L190) for the `important_declarations`.