### PR TITLE
Node: Add type inference for TransformResult

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -52,16 +52,26 @@ export interface PseudoClasses {
   focusWithin?: string
 }
 
-export interface TransformResult {
+export interface TransformResult<Options extends BundleOptions = BundleOptions> {
   /** The transformed code. */
   code: Buffer,
   /** The generated source map, if enabled. */
-  map: Buffer | void,
+  map: ConditionalOutput<Options, "sourceMap", Buffer>,
   /** CSS module exports, if enabled. */
-  exports: CSSModuleExports | void,
+  exports: ConditionalOutput<Options, "cssModules", CSSModuleExports>,
   /** `@import` and `url()` dependencies, if enabled. */
-  dependencies: Dependency[] | void
+  dependencies: ConditionalOutput<Options, "analyzeDependencies", Dependency[]>
 }
+
+type ConditionalOutput<
+  Options extends BundleOptions,
+  OptionKey extends keyof BundleOptions,
+  Value,
+> = Options[OptionKey] extends true
+  ? Value
+  : Options[OptionKey] extends false | undefined
+    ? void
+    : Value | void;
 
 export type CSSModuleExports = {
   /** Maps exported (i.e. original) names to local names. */
@@ -143,7 +153,7 @@ export interface Location {
  * Compiles a CSS file, including optionally minifying and lowering syntax to the given
  * targets. A source map may also be generated, but this is not enabled by default.
  */
-export declare function transform(options: TransformOptions): TransformResult;
+export declare function transform<Options extends TransformOptions>(options: Options): TransformResult<Options>;
 
 export interface TransformAttributeOptions {
   /** The source code to transform. */
@@ -182,4 +192,4 @@ export declare function browserslistToTargets(browserslist: string[]): Targets;
 /**
  * Bundles a CSS file and its dependencies, inlining @import rules.
  */
-export declare function bundle(options: BundleOptions): TransformResult;
+export declare function bundle<Options extends BundleOptions>(options: Options): TransformResult<Options>;


### PR DESCRIPTION
This PR improves nullability of transform and bundle outputs.

```ts
let {code, map} = css.transform({
  filename: 'style.css',
  code: Buffer.from('.foo { color: red }'),
  sourceMap: true,
});
console.log(map.toString()); // Valid in TS without assertion 🎉
```

Note: Prettier seems to not be applied on this file, so I tried to follow formatting conventions manually.