### PR TITLE
fix: `font-family: revert/revert-layer` cannot remove quotation marks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3636,7 +3636,17 @@ mod tests {
     minify_test(".foo { font-family: inherit; }", ".foo{font-family:inherit}");
     minify_test(".foo { font-family: inherit test; }", ".foo{font-family:inherit test}");
     minify_test(".foo { font-family: 'inherit test'; }", ".foo{font-family:inherit test}");
+    minify_test(".foo { font-family: revert; }", ".foo{font-family:revert}");
+    minify_test(".foo { font-family: 'revert'; }", ".foo{font-family:\"revert\"}");
+    minify_test(".foo { font-family: revert-layer; }", ".foo{font-family:revert-layer}");
+    minify_test(".foo { font-family: revert-layer, serif; }", ".foo{font-family:revert-layer,serif}");
+    minify_test(".foo { font-family: 'revert', sans-serif; }", ".foo{font-family:\"revert\",sans-serif}");
+    minify_test(".foo { font-family: 'revert', foo, sans-serif; }", ".foo{font-family:\"revert\",foo,sans-serif}");
     minify_test(".foo { font-family: ''; }", ".foo{font-family:\"\"}");
+
+    // font-family in @font-face
+    minify_test("@font-face { font-family: 'revert'; }", "@font-face{font-family:\"revert\"}");
+    minify_test("@font-face { font-family: 'revert-layer'; }", "@font-face{font-family:\"revert-layer\"}");
   }
 
   #[test]

--- a/src/properties/font.rs
+++ b/src/properties/font.rs
@@ -263,6 +263,11 @@ enum_property! {
     // Default is also reserved by the <custom-ident> type.
     // https://www.w3.org/TR/css-values-4/#custom-idents
     "default": Default,
+
+    // CSS defaulting keywords
+    // https://drafts.csswg.org/css-cascade-5/#defaulting-keywords
+    "revert": Revert,
+    "revert-layer": RevertLayer,
   }
 }
 


### PR DESCRIPTION
CSS wide keywords are confusingly defined(see https://github.com/w3c/csswg-drafts/issues/7170), we left out `revert` and `revert-layer`, and we can't remove the quotes when these keywords are present.



Improvement #120