### PR TITLE
CI on PRs, fix build warning, fixed rust version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,21 @@
 name: test
+
 on:
   push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: full
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v1
       - run: cargo fmt
       - run: cargo test

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.59.0"
+components = ["rustfmt", "clippy"]

--- a/src/media_query.rs
+++ b/src/media_query.rs
@@ -808,7 +808,7 @@ fn process_condition<'i>(
     }
     MediaCondition::Operation(conditions, _) => {
       let mut res = Ok(true);
-      conditions.retain_mut(|condition| {
+      RetainMut::retain_mut(conditions, |condition| {
         let r = process_condition(loc, custom_media, media_type, qualifier, condition, seen);
         if let Ok(used) = r {
           used


### PR DESCRIPTION
This commit updates CI to also run on PRs. Additionally CI now fails if
build warnings are encountered.

A `rust-toolchain.toml` file has been added to the root of the repo that
ensures that all collaboraters use the same up-to-date Rust version.
Cargo picks up this file automatically and uses rustup to install and
use the right version of rustc and cargo for each project.

CI now also adheres to this toolchain file through the use of
`dtolnay/rust-toolchain@stable`.
