### PR TITLE
Fix extraneous trailing space for border property

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -759,6 +759,29 @@ mod tests {
     "#},
     );
 
+    test(
+      r#"
+      .foo {
+        border: 1px solid currentColor;
+      }
+    "#,
+      indoc! {r#"
+      .foo {
+        border: 1px solid;
+      }
+    "#
+      },
+    );
+
+    minify_test(
+      r#"
+      .foo {
+        border: 1px solid currentColor;
+      }
+    "#,
+      ".foo{border:1px solid}",
+    );
+
     prefix_test(
       r#"
       .foo {

--- a/src/properties/border.rs
+++ b/src/properties/border.rs
@@ -162,13 +162,13 @@ impl<S: ToCss + Default + PartialEq> ToCss for GenericBorder<S> {
 
     if self.width != BorderSideWidth::default() {
       self.width.to_css(dest)?;
-      dest.write_str(" ")?;
     }
     if self.style != S::default() {
-      self.style.to_css(dest)?;
       dest.write_str(" ")?;
+      self.style.to_css(dest)?;
     }
     if self.color != CssColor::current_color() {
+      dest.write_str(" ")?;
       self.color.to_css(dest)?;
     }
     Ok(())


### PR DESCRIPTION
If just color, or color and style for a border were ommited, an
extraneous space char would be present at the end of the property value
output. This commit fixes this by inserting spaces before values rather
than after.

Fixes #130