### PR TITLE
Expose Parse and ToCss traits

### DIFF
--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -1,5 +1,5 @@
 use crate::css_modules::hash;
-use crate::printer::Printer;
+use crate::printer::PrinterOptions;
 use crate::rules::import::ImportRule;
 use crate::traits::ToCss;
 use crate::values::url::Url;
@@ -24,18 +24,14 @@ pub struct ImportDependency {
 impl ImportDependency {
   pub fn new(rule: &ImportRule, filename: &str) -> ImportDependency {
     let supports = if let Some(supports) = &rule.supports {
-      let mut s = String::new();
-      let mut printer = Printer::new(&mut s, None, false, None);
-      supports.to_css(&mut printer).unwrap();
+      let s = supports.to_css_string(PrinterOptions::default()).unwrap();
       Some(s)
     } else {
       None
     };
 
     let media = if !rule.media.media_queries.is_empty() {
-      let mut s = String::new();
-      let mut printer = Printer::new(&mut s, None, false, None);
-      rule.media.to_css(&mut printer).unwrap();
+      let s = rule.media.to_css_string(PrinterOptions::default()).unwrap();
       Some(s)
     } else {
       None

--- a/src/media_query.rs
+++ b/src/media_query.rs
@@ -905,6 +905,7 @@ fn process_condition<'i>(
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::stylesheet::PrinterOptions;
 
   fn parse(s: &str) -> MediaQuery {
     let mut input = ParserInput::new(&s);
@@ -916,7 +917,7 @@ mod tests {
     let mut a = parse(a);
     let b = parse(b);
     a.and(&b).unwrap();
-    a.to_css_string()
+    a.to_css_string(PrinterOptions::default()).unwrap()
   }
 
   #[test]

--- a/src/properties/transform.rs
+++ b/src/properties/transform.rs
@@ -5,6 +5,7 @@ use crate::error::{ParserError, PrinterError};
 use crate::macros::enum_property;
 use crate::prefixes::Feature;
 use crate::printer::Printer;
+use crate::stylesheet::PrinterOptions;
 use crate::targets::Browsers;
 use crate::traits::{Parse, PropertyHandler, ToCss};
 use crate::values::{
@@ -53,13 +54,25 @@ impl ToCss for TransformList {
       if let Some(matrix) = self.to_matrix() {
         // Generate based on the original transforms.
         let mut base = String::new();
-        self.to_css_base(&mut Printer::new(&mut base, None, true, None))?;
+        self.to_css_base(&mut Printer::new(
+          &mut base,
+          PrinterOptions {
+            minify: true,
+            ..PrinterOptions::default()
+          },
+        ))?;
 
         // Decompose the matrix into transform functions if possible.
         // If the resulting length is shorter than the original, use it.
         if let Some(d) = matrix.decompose() {
           let mut decomposed = String::new();
-          d.to_css_base(&mut Printer::new(&mut decomposed, None, true, None))?;
+          d.to_css_base(&mut Printer::new(
+            &mut decomposed,
+            PrinterOptions {
+              minify: true,
+              ..PrinterOptions::default()
+            },
+          ))?;
           if decomposed.len() < base.len() {
             base = decomposed;
           }
@@ -68,9 +81,21 @@ impl ToCss for TransformList {
         // Also generate a matrix() or matrix3d() representation and compare that.
         let mut mat = String::new();
         if let Some(matrix) = matrix.to_matrix2d() {
-          Transform::Matrix(matrix).to_css(&mut Printer::new(&mut mat, None, true, None))?
+          Transform::Matrix(matrix).to_css(&mut Printer::new(
+            &mut mat,
+            PrinterOptions {
+              minify: true,
+              ..PrinterOptions::default()
+            },
+          ))?
         } else {
-          Transform::Matrix3d(matrix).to_css(&mut Printer::new(&mut mat, None, true, None))?
+          Transform::Matrix3d(matrix).to_css(&mut Printer::new(
+            &mut mat,
+            PrinterOptions {
+              minify: true,
+              ..PrinterOptions::default()
+            },
+          ))?
         }
 
         if mat.len() < base.len() {

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -2,6 +2,7 @@ use crate::compat::Feature;
 use crate::error::{ParserError, PrinterError};
 use crate::printer::Printer;
 use crate::rules::{StyleContext, ToCssWithContext};
+use crate::stylesheet::PrinterOptions;
 use crate::targets::Browsers;
 use crate::traits::{Parse, ToCss};
 use crate::vendor_prefix::VendorPrefix;
@@ -82,7 +83,7 @@ impl<'i> SelectorImpl<'i> for Selectors {
   type ExtraMatchingData = ();
 
   fn to_css<W: fmt::Write>(selectors: &SelectorList<'i, Self>, dest: &mut W) -> std::fmt::Result {
-    let mut printer = Printer::new(dest, None, false, None);
+    let mut printer = Printer::new(dest, PrinterOptions::default());
     serialize_selector_list(selectors.0.iter(), &mut printer, None, false).map_err(|_| std::fmt::Error)
   }
 }

--- a/src/values/angle.rs
+++ b/src/values/angle.rs
@@ -3,7 +3,7 @@ use super::length::serialize_dimension;
 use super::percentage::DimensionPercentage;
 use crate::error::{ParserError, PrinterError};
 use crate::printer::Printer;
-use crate::traits::{Parse, ToCss, TryAdd};
+use crate::traits::{private::TryAdd, Parse, ToCss};
 use cssparser::*;
 use std::f32::consts::PI;
 

--- a/src/values/length.rs
+++ b/src/values/length.rs
@@ -3,7 +3,7 @@ use super::number::serialize_number;
 use super::percentage::DimensionPercentage;
 use crate::error::{ParserError, PrinterError};
 use crate::printer::Printer;
-use crate::traits::{Parse, ToCss, TryAdd};
+use crate::traits::{private::TryAdd, Parse, ToCss};
 use const_str;
 use cssparser::*;
 

--- a/src/values/percentage.rs
+++ b/src/values/percentage.rs
@@ -2,7 +2,7 @@ use super::calc::Calc;
 use super::number::serialize_number;
 use crate::error::{ParserError, PrinterError};
 use crate::printer::Printer;
-use crate::traits::{Parse, ToCss, TryAdd};
+use crate::traits::{private::TryAdd, Parse, ToCss};
 use cssparser::*;
 
 /// https://drafts.csswg.org/css-values-4/#percentages


### PR DESCRIPTION
Part of #5.

This exposes the `Parse` and `ToCss` traits, which can be used to parse and serialize individual CSS rules, properties, and values rather than only entire stylesheets. I also added `parse_string` and `to_css_string` convenience functions to parse and serialize from a string, without manually constructing a parser/printer from scratch.

By extension, this means the `Printer` is also exposed. I've refactored it a little to accept an options struct and also to hide internal fields.

Example:

```rust
use parcel_css::{
  properties::Property,
  rules::CssRule,
  stylesheet::{ParserOptions, PrinterOptions},
  traits::{Parse, ToCss},
  values::color::CssColor,
};

// Parse and serialize an individual value
let color = CssColor::parse_string("#f0f")?;
color.to_css_string(PrinterOptions::default())?; // => "#f0f"

// Parse a property by name
let property = Property::parse_string("color", "#f0f", ParserOptions::default())?;
property.to_css_string(/* important */ false, PrinterOptions::default())?; // => "color: #f0f"

// Parse a single rule
let rule = CssRule::parse_string(".foo { color: red; }", ParserOptions::default())?;
rule.to_css_string(PrinterOptions::default())?; // => ".foo {\n  color: red;\n}"
```

cc. @lucacasonato 