### PR TITLE
Add method to lazily compute property source ranges

### DIFF
--- a/src/declaration.rs
+++ b/src/declaration.rs
@@ -1,5 +1,7 @@
 //! CSS declarations.
 
+use std::ops::Range;
+
 use crate::context::PropertyHandlerContext;
 use crate::error::{ParserError, PrinterError};
 use crate::parser::ParserOptions;
@@ -139,6 +141,43 @@ impl<'i> DeclarationBlock<'i> {
   /// Returns whether the declaration block is empty.
   pub fn is_empty(&self) -> bool {
     return self.declarations.is_empty() && self.important_declarations.is_empty();
+  }
+
+  pub(crate) fn property_location<'t>(
+    &self,
+    input: &mut Parser<'i, 't>,
+    index: usize,
+  ) -> Result<(Range<SourceLocation>, Range<SourceLocation>), ParseError<'i, ParserError<'i>>> {
+    // Skip to the requested property index.
+    for _ in 0..index {
+      input.expect_ident()?;
+      input.expect_colon()?;
+      input.parse_until_after(Delimiter::Semicolon, |parser| {
+        while parser.next().is_ok() {}
+        Ok(())
+      })?;
+    }
+
+    // Get property name range.
+    input.skip_whitespace();
+    let key_start = input.current_source_location();
+    input.expect_ident()?;
+    let key_end = input.current_source_location();
+    let key_range = key_start..key_end;
+
+    input.expect_colon()?;
+    input.skip_whitespace();
+
+    // Get value range.
+    let val_start = input.current_source_location();
+    input.parse_until_before(Delimiter::Semicolon, |parser| {
+      while parser.next().is_ok() {}
+      Ok(())
+    })?;
+    let val_end = input.current_source_location();
+    let val_range = val_start..val_end;
+
+    Ok((key_range, val_range))
   }
 }
 

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -104,7 +104,7 @@ pub struct SourceRange {
   pub file_path: String,
   /// The starting line and column position of the dependency.
   pub start: Location,
-  /// THe ending line and column position of the dependency.
+  /// The ending line and column position of the dependency.
   pub end: Location,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,7 +36,7 @@ pub struct ErrorLocation {
   pub filename: String,
   /// The line number, starting from 0.
   pub line: u32,
-  /// THe column number, starting from 1.
+  /// The column number, starting from 1.
   pub column: u32,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ mod tests {
   use crate::targets::Browsers;
   use crate::traits::{Parse, ToCss};
   use crate::values::color::CssColor;
+  use cssparser::SourceLocation;
   use indoc::indoc;
   use std::collections::HashMap;
 
@@ -17807,6 +17808,60 @@ mod tests {
       property.to_css_string(true, PrinterOptions::default()).unwrap(),
       "color: #f0f !important"
     );
+
+    let code = indoc! { r#"
+      .foo {
+        color: green;
+      }
+
+      .bar {
+        color: red;
+        background: pink;
+      }
+
+      @media print {
+        .baz {
+          color: green;
+        }
+      }
+    "#};
+    let stylesheet = StyleSheet::parse("test.css", code, ParserOptions::default()).unwrap();
+    if let CssRule::Style(style) = &stylesheet.rules.0[1] {
+      let (key, val) = style.property_location(code, 0).unwrap();
+      assert_eq!(
+        key,
+        SourceLocation { line: 5, column: 3 }..SourceLocation { line: 5, column: 8 }
+      );
+      assert_eq!(
+        val,
+        SourceLocation { line: 5, column: 10 }..SourceLocation { line: 5, column: 13 }
+      );
+    }
+
+    if let CssRule::Style(style) = &stylesheet.rules.0[1] {
+      let (key, val) = style.property_location(code, 1).unwrap();
+      assert_eq!(
+        key,
+        SourceLocation { line: 6, column: 3 }..SourceLocation { line: 6, column: 13 }
+      );
+      assert_eq!(
+        val,
+        SourceLocation { line: 6, column: 15 }..SourceLocation { line: 6, column: 19 }
+      );
+    }
+    if let CssRule::Media(media) = &stylesheet.rules.0[2] {
+      if let CssRule::Style(style) = &media.rules.0[0] {
+        let (key, val) = style.property_location(code, 0).unwrap();
+        assert_eq!(
+          key,
+          SourceLocation { line: 11, column: 5 }..SourceLocation { line: 11, column: 10 }
+        );
+        assert_eq!(
+          val,
+          SourceLocation { line: 11, column: 12 }..SourceLocation { line: 11, column: 17 }
+        );
+      }
+    }
   }
 
   #[test]


### PR DESCRIPTION
Closes #168

We don't store source locations for every property/value currently, because that would use a lot of additional memory, and it's rare to need source locations except in errors. So this adds a method to lazily compute the source locations of the keys/values of declarations within a style rule. Essentially, it performs a very lightweight additional parsing pass to first find the stored location of the parent style rule, and then finding the declaration by index from there.

This approach is somewhat error prone (e.g. if you modified the style sheet) so I'm not sure if it's a good idea or not. Alternatives would be to store source locations for everything, which I'd prefer not to do if we can help it, or somehow optionally store them externally (but I'm not sure how).