### PR TITLE
Add `resolve()` method to `SourceProvider`

### DIFF
--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -574,12 +574,14 @@ mod tests {
       .code
   }
 
-  fn error_test(fs: TestProvider, entry: &str) {
+  fn error_test(fs: TestProvider, entry: &str, maybe_cb: Option<Box<dyn FnOnce(BundleErrorKind) -> ()>>) {
     let mut bundler = Bundler::new(&fs, None, ParserOptions::default());
     let res = bundler.bundle(Path::new(entry));
     match res {
       Ok(_) => unreachable!(),
-      Err(e) => assert!(matches!(e.kind, BundleErrorKind::UnsupportedLayerCombination)),
+      Err(e) => if let Some(cb) = maybe_cb {
+        cb(e.kind);
+      }
     }
   }
 
@@ -1142,6 +1144,9 @@ mod tests {
         },
       },
       "/a.css",
+      Some(Box::new(|err| {
+        assert!(matches!(err, BundleErrorKind::UnsupportedLayerCombination));
+      })),
     );
 
     error_test(
@@ -1157,6 +1162,9 @@ mod tests {
         },
       },
       "/a.css",
+      Some(Box::new(|err| {
+        assert!(matches!(err, BundleErrorKind::UnsupportedLayerCombination));
+      })),
     );
 
     error_test(
@@ -1176,6 +1184,9 @@ mod tests {
         },
       },
       "/a.css",
+      Some(Box::new(|err| {
+        assert!(matches!(err, BundleErrorKind::UnsupportedLayerCombination));
+      })),
     );
 
     error_test(
@@ -1195,6 +1206,9 @@ mod tests {
         },
       },
       "/a.css",
+      Some(Box::new(|err| {
+        assert!(matches!(err, BundleErrorKind::UnsupportedLayerCombination));
+      })),
     );
 
     let res = bundle(

--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -521,20 +521,18 @@ mod tests {
         $(
           m.insert(PathBuf::from($key), $value.to_owned());
         )*
-        TestProvider {
-          map: m
-        }
+        m
       }
     };
   );
 
-  fn bundle(fs: TestProvider, entry: &str) -> String {
+  fn bundle<P: SourceProvider>(fs: P, entry: &str) -> String {
     let mut bundler = Bundler::new(&fs, None, ParserOptions::default());
     let stylesheet = bundler.bundle(Path::new(entry)).unwrap();
     stylesheet.to_css(PrinterOptions::default()).unwrap().code
   }
 
-  fn bundle_css_module(fs: TestProvider, entry: &str) -> String {
+  fn bundle_css_module<P: SourceProvider>(fs: P, entry: &str) -> String {
     let mut bundler = Bundler::new(
       &fs,
       None,
@@ -547,7 +545,7 @@ mod tests {
     stylesheet.to_css(PrinterOptions::default()).unwrap().code
   }
 
-  fn bundle_custom_media(fs: TestProvider, entry: &str) -> String {
+  fn bundle_custom_media<P: SourceProvider>(fs: P, entry: &str) -> String {
     let mut bundler = Bundler::new(
       &fs,
       None,
@@ -588,14 +586,16 @@ mod tests {
   #[test]
   fn test_bundle() {
     let res = bundle(
-      fs! {
-        "/a.css": r#"
-        @import "b.css";
-        .a { color: red }
-      "#,
-        "/b.css": r#"
-        .b { color: green }
-      "#
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @import "b.css";
+          .a { color: red }
+        "#,
+          "/b.css": r#"
+          .b { color: green }
+        "#
+        },
       },
       "/a.css",
     );
@@ -613,14 +613,16 @@ mod tests {
     );
 
     let res = bundle(
-      fs! {
-        "/a.css": r#"
-        @import "b.css" print;
-        .a { color: red }
-      "#,
-        "/b.css": r#"
-        .b { color: green }
-      "#
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @import "b.css" print;
+          .a { color: red }
+        "#,
+          "/b.css": r#"
+          .b { color: green }
+        "#
+        },
       },
       "/a.css",
     );
@@ -640,14 +642,16 @@ mod tests {
     );
 
     let res = bundle(
-      fs! {
-        "/a.css": r#"
-        @import "b.css" supports(color: green);
-        .a { color: red }
-      "#,
-        "/b.css": r#"
-        .b { color: green }
-      "#
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @import "b.css" supports(color: green);
+          .a { color: red }
+        "#,
+          "/b.css": r#"
+          .b { color: green }
+        "#
+        },
       },
       "/a.css",
     );
@@ -667,14 +671,16 @@ mod tests {
     );
 
     let res = bundle(
-      fs! {
-        "/a.css": r#"
-        @import "b.css" supports(color: green) print;
-        .a { color: red }
-      "#,
-        "/b.css": r#"
-        .b { color: green }
-      "#
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @import "b.css" supports(color: green) print;
+          .a { color: red }
+        "#,
+          "/b.css": r#"
+          .b { color: green }
+        "#
+        },
       },
       "/a.css",
     );
@@ -696,15 +702,17 @@ mod tests {
     );
 
     let res = bundle(
-      fs! {
-        "/a.css": r#"
-        @import "b.css" print;
-        @import "b.css" screen;
-        .a { color: red }
-      "#,
-        "/b.css": r#"
-        .b { color: green }
-      "#
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @import "b.css" print;
+          @import "b.css" screen;
+          .a { color: red }
+        "#,
+          "/b.css": r#"
+          .b { color: green }
+        "#
+        },
       },
       "/a.css",
     );
@@ -724,15 +732,17 @@ mod tests {
     );
 
     let res = bundle(
-      fs! {
-        "/a.css": r#"
-        @import "b.css" supports(color: red);
-        @import "b.css" supports(foo: bar);
-        .a { color: red }
-      "#,
-        "/b.css": r#"
-        .b { color: green }
-      "#
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @import "b.css" supports(color: red);
+          @import "b.css" supports(foo: bar);
+          .a { color: red }
+        "#,
+          "/b.css": r#"
+          .b { color: green }
+        "#
+        },
       },
       "/a.css",
     );
@@ -752,18 +762,20 @@ mod tests {
     );
 
     let res = bundle(
-      fs! {
-        "/a.css": r#"
-        @import "b.css" print;
-        .a { color: red }
-      "#,
-        "/b.css": r#"
-        @import "c.css" (color);
-        .b { color: yellow }
-      "#,
-        "/c.css": r#"
-        .c { color: green }
-      "#
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @import "b.css" print;
+          .a { color: red }
+        "#,
+          "/b.css": r#"
+          @import "c.css" (color);
+          .b { color: yellow }
+        "#,
+          "/c.css": r#"
+          .c { color: green }
+        "#
+        },
       },
       "/a.css",
     );
@@ -789,18 +801,20 @@ mod tests {
     );
 
     let res = bundle(
-      fs! {
-        "/a.css": r#"
-        @import "b.css";
-        .a { color: red }
-      "#,
-        "/b.css": r#"
-        @import "c.css";
-      "#,
-        "/c.css": r#"
-        @import "a.css";
-        .c { color: green }
-      "#
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @import "b.css";
+          .a { color: red }
+        "#,
+          "/b.css": r#"
+          @import "c.css";
+        "#,
+          "/c.css": r#"
+          @import "a.css";
+          .c { color: green }
+        "#
+        },
       },
       "/a.css",
     );
@@ -818,14 +832,16 @@ mod tests {
     );
 
     let res = bundle(
-      fs! {
-        "/a.css": r#"
-        @import "b/c.css";
-        .a { color: red }
-      "#,
-        "/b/c.css": r#"
-        .b { color: green }
-      "#
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @import "b/c.css";
+          .a { color: red }
+        "#,
+          "/b/c.css": r#"
+          .b { color: green }
+        "#
+        },
       },
       "/a.css",
     );
@@ -843,14 +859,16 @@ mod tests {
     );
 
     let res = bundle(
-      fs! {
-        "/a.css": r#"
-        @import "./b/c.css";
-        .a { color: red }
-      "#,
-        "/b/c.css": r#"
-        .b { color: green }
-      "#
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @import "./b/c.css";
+          .a { color: red }
+        "#,
+          "/b/c.css": r#"
+          .b { color: green }
+        "#
+        },
       },
       "/a.css",
     );
@@ -868,14 +886,16 @@ mod tests {
     );
 
     let res = bundle_css_module(
-      fs! {
-        "/a.css": r#"
-        @import "b.css";
-        .a { color: red }
-      "#,
-        "/b.css": r#"
-        .a { color: green }
-      "#
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @import "b.css";
+          .a { color: red }
+        "#,
+          "/b.css": r#"
+          .a { color: green }
+        "#
+        },
       },
       "/a.css",
     );
@@ -893,20 +913,22 @@ mod tests {
     );
 
     let res = bundle_custom_media(
-      fs! {
-        "/a.css": r#"
-        @import "media.css";
-        @import "b.css";
-        .a { color: red }
-      "#,
-        "/media.css": r#"
-        @custom-media --foo print;
-      "#,
-        "/b.css": r#"
-        @media (--foo) {
-          .a { color: green }
-        }
-      "#
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @import "media.css";
+          @import "b.css";
+          .a { color: red }
+        "#,
+          "/media.css": r#"
+          @custom-media --foo print;
+        "#,
+          "/b.css": r#"
+          @media (--foo) {
+            .a { color: green }
+          }
+        "#
+        },
       },
       "/a.css",
     );
@@ -926,14 +948,16 @@ mod tests {
     );
 
     let res = bundle(
-      fs! {
-        "/a.css": r#"
-        @import "b.css" layer(foo);
-        .a { color: red }
-      "#,
-        "/b.css": r#"
-        .b { color: green }
-      "#
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @import "b.css" layer(foo);
+          .a { color: red }
+        "#,
+          "/b.css": r#"
+          .b { color: green }
+        "#
+        },
       },
       "/a.css",
     );
@@ -953,14 +977,16 @@ mod tests {
     );
 
     let res = bundle(
-      fs! {
-        "/a.css": r#"
-        @import "b.css" layer;
-        .a { color: red }
-      "#,
-        "/b.css": r#"
-        .b { color: green }
-      "#
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @import "b.css" layer;
+          .a { color: red }
+        "#,
+          "/b.css": r#"
+          .b { color: green }
+        "#
+        },
       },
       "/a.css",
     );
@@ -980,18 +1006,20 @@ mod tests {
     );
 
     let res = bundle(
-      fs! {
-        "/a.css": r#"
-        @import "b.css" layer(foo);
-        .a { color: red }
-      "#,
-        "/b.css": r#"
-        @import "c.css" layer(bar);
-        .b { color: green }
-      "#,
-        "/c.css": r#"
-        .c { color: green }
-      "#
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @import "b.css" layer(foo);
+          .a { color: red }
+        "#,
+          "/b.css": r#"
+          @import "c.css" layer(bar);
+          .b { color: green }
+        "#,
+          "/c.css": r#"
+          .c { color: green }
+        "#
+        },
       },
       "/a.css",
     );
@@ -1017,14 +1045,16 @@ mod tests {
     );
 
     let res = bundle(
-      fs! {
-        "/a.css": r#"
-        @import "b.css" layer(foo);
-        @import "b.css" layer(foo);
-      "#,
-        "/b.css": r#"
-        .b { color: green }
-      "#
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @import "b.css" layer(foo);
+          @import "b.css" layer(foo);
+        "#,
+          "/b.css": r#"
+          .b { color: green }
+        "#
+        },
       },
       "/a.css",
     );
@@ -1040,32 +1070,34 @@ mod tests {
     );
 
     let res = bundle(
-      fs! {
-        "/a.css": r#"
-        @layer bar, foo;
-        @import "b.css" layer(foo);
-        
-        @layer bar {
-          div {
-            background: red;
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @layer bar, foo;
+          @import "b.css" layer(foo);
+          
+          @layer bar {
+            div {
+              background: red;
+            }
           }
-        }
-      "#,
-        "/b.css": r#"
-        @layer qux, baz;
-        @import "c.css" layer(baz);
-        
-        @layer qux {
-          div {
-            background: green;
+        "#,
+          "/b.css": r#"
+          @layer qux, baz;
+          @import "c.css" layer(baz);
+          
+          @layer qux {
+            div {
+              background: green;
+            }
           }
-        }
-      "#,
-        "/c.css": r#"
-        div {
-          background: yellow;
-        }      
-      "#
+        "#,
+          "/c.css": r#"
+          div {
+            background: yellow;
+          }      
+        "#
+        },
       },
       "/a.css",
     );
@@ -1098,85 +1130,95 @@ mod tests {
     );
 
     error_test(
-      fs! {
-        "/a.css": r#"
-        @import "b.css" layer(foo);
-        @import "b.css" layer(bar);
-      "#,
-        "/b.css": r#"
-        .b { color: red }
-      "#
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @import "b.css" layer(foo);
+          @import "b.css" layer(bar);
+        "#,
+          "/b.css": r#"
+          .b { color: red }
+        "#
+        },
       },
       "/a.css",
     );
 
     error_test(
-      fs! {
-        "/a.css": r#"
-        @import "b.css" layer;
-        @import "b.css" layer;
-      "#,
-        "/b.css": r#"
-        .b { color: red }
-      "#
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @import "b.css" layer;
+          @import "b.css" layer;
+        "#,
+          "/b.css": r#"
+          .b { color: red }
+        "#
+        },
       },
       "/a.css",
     );
 
     error_test(
-      fs! {
-        "/a.css": r#"
-        @import "b.css" layer;
-        .a { color: red }
-      "#,
-        "/b.css": r#"
-        @import "c.css" layer;
-        .b { color: green }
-      "#,
-        "/c.css": r#"
-        .c { color: green }
-      "#
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @import "b.css" layer;
+          .a { color: red }
+        "#,
+          "/b.css": r#"
+          @import "c.css" layer;
+          .b { color: green }
+        "#,
+          "/c.css": r#"
+          .c { color: green }
+        "#
+        },
       },
       "/a.css",
     );
 
     error_test(
-      fs! {
-        "/a.css": r#"
-        @import "b.css" layer;
-        .a { color: red }
-      "#,
-        "/b.css": r#"
-        @import "c.css" layer(foo);
-        .b { color: green }
-      "#,
-        "/c.css": r#"
-        .c { color: green }
-      "#
+      TestProvider {
+        map: fs! {
+          "/a.css": r#"
+          @import "b.css" layer;
+          .a { color: red }
+        "#,
+          "/b.css": r#"
+          @import "c.css" layer(foo);
+          .b { color: green }
+        "#,
+          "/c.css": r#"
+          .c { color: green }
+        "#
+        },
       },
       "/a.css",
     );
 
     let res = bundle(
-      fs! {
-        "/index.css": r#"
-        @import "a.css";
-        @import "b.css";
-      "#,
-        "/a.css": r#"
-        @import "./c.css";
-        body { background: red; }
-      "#,
-        "/b.css": r#"
-        @import "./c.css";
-        body { color: red; }
-      "#,
-        "/c.css": r#"
-        body {
-          background: white;
-          color: black; 
-        }
-      "#
+      TestProvider {
+        map: fs! {
+          "/index.css": r#"
+          @import "a.css";
+          @import "b.css";
+        "#,
+          "/a.css": r#"
+          @import "./c.css";
+          body { background: red; }
+        "#,
+          "/b.css": r#"
+          @import "./c.css";
+          body { color: red; }
+        "#,
+          "/c.css": r#"
+          body {
+            background: white;
+            color: black; 
+          }
+        "#
+        },
       },
       "/index.css",
     );
@@ -1199,18 +1241,20 @@ mod tests {
     );
 
     let res = bundle(
-      fs! {
-        "/index.css": r#"
-        @import "a.css";
-        @import "b.css";
-        @import "a.css";
-      "#,
-        "/a.css": r#"
-        body { background: green; }
-      "#,
-        "/b.css": r#"
-        body { background: red; }
-      "#
+      TestProvider {
+        map: fs! {
+          "/index.css": r#"
+          @import "a.css";
+          @import "b.css";
+          @import "a.css";
+        "#,
+          "/a.css": r#"
+          body { background: green; }
+        "#,
+          "/b.css": r#"
+          body { background: red; }
+        "#
+        },
       },
       "/index.css",
     );


### PR DESCRIPTION
This adds a new `resolve()` method to `SourceProvider` which is responsible for resolving an `@import` specifier into a file path. `FileProvider` still uses the default behavior of assuming the specifier is a relative path and joining it with the path of the originating file. This provides a hook for custom `SourceProviders` to implement their own application-specific resolution logic.

This required a couple minor refactors in the `fs!` and `error_test()` utilities to make them more flexible and support testing a custom resolver.

I've done a little Rust, but I'm not terribly familiar with it, so please let me know if I'm doing anything unidiomatic. Some of the areas I struggled with and am not convinced I found the ideal solution:
1. `error_test()` accepts a callback which runs assertions. This was the only way I could reuse the function to assert different error kinds, since the only way to compare the `BundleErrorKind` enum is with `matches!()`, and a match expression can't really work as a function input. I tried to return the error instead, but that ran into ownership issues since it outlived the bundler, and I couldn't find a good solution there.
2. I wanted the bundler to automatically prepend any resolver errors with "Failed to resolve {}:\n...", so that the context of the failure is always present, even if the resolver itself gave a bad error message. Unfortunately I couldn't find a good way of wrapping the error message from the resolver since it might not be an `IOError` with a `NotFound` kind, so it may not have an error message to wrap, and reaching into that felt a little too intrusive.

Refs #174.