### PR TITLE
Add support for custom css modules name patterns

### DIFF
--- a/src/css_modules.rs
+++ b/src/css_modules.rs
@@ -32,7 +32,8 @@ pub struct Config<'i> {
 /// A CSS modules class name pattern.
 #[derive(Clone, Debug)]
 pub struct Pattern<'i> {
-  segments: SmallVec<[Segment<'i>; 2]>,
+  /// The list of segments in the pattern.
+  pub segments: SmallVec<[Segment<'i>; 2]>,
 }
 
 impl<'i> Default for Pattern<'i> {
@@ -251,12 +252,6 @@ impl<'a, 'b, 'c> CssModule<'a, 'b, 'c> {
 
     Ok(())
   }
-}
-
-fn get_hashed_name(hash: &str, name: &str) -> String {
-  // Hash must come first so that CSS grid identifiers work.
-  // This is because grid lines may have an implicit -start or -end appended.
-  format!("{}_{}", hash, name)
 }
 
 pub(crate) fn hash(s: &str, at_start: bool) -> String {

--- a/src/declaration.rs
+++ b/src/declaration.rs
@@ -52,9 +52,9 @@ pub struct DeclarationBlock<'i> {
 
 impl<'i> DeclarationBlock<'i> {
   /// Parses a declaration block from CSS syntax.
-  pub fn parse<'t>(
+  pub fn parse<'a, 'o, 't>(
     input: &mut Parser<'i, 't>,
-    options: &ParserOptions,
+    options: &'a ParserOptions<'o>,
   ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
     let mut important_declarations = DeclarationList::new();
     let mut declarations = DeclarationList::new();
@@ -79,7 +79,10 @@ impl<'i> DeclarationBlock<'i> {
   }
 
   /// Parses a declaration block from a string.
-  pub fn parse_string(input: &'i str, options: ParserOptions) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+  pub fn parse_string<'o>(
+    input: &'i str,
+    options: ParserOptions<'o>,
+  ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
     let mut input = ParserInput::new(input);
     let mut parser = Parser::new(&mut input);
     let result = Self::parse(&mut parser, &options)?;
@@ -371,14 +374,14 @@ impl<'i> DeclarationBlock<'i> {
   }
 }
 
-struct PropertyDeclarationParser<'a, 'i> {
+struct PropertyDeclarationParser<'a, 'o, 'i> {
   important_declarations: &'a mut Vec<Property<'i>>,
   declarations: &'a mut Vec<Property<'i>>,
-  options: &'a ParserOptions,
+  options: &'a ParserOptions<'o>,
 }
 
 /// Parse a declaration within {} block: `color: blue`
-impl<'a, 'i> cssparser::DeclarationParser<'i> for PropertyDeclarationParser<'a, 'i> {
+impl<'a, 'o, 'i> cssparser::DeclarationParser<'i> for PropertyDeclarationParser<'a, 'o, 'i> {
   type Declaration = ();
   type Error = ParserError<'i>;
 
@@ -398,7 +401,7 @@ impl<'a, 'i> cssparser::DeclarationParser<'i> for PropertyDeclarationParser<'a, 
 }
 
 /// Default methods reject all at rules.
-impl<'a, 'i> AtRuleParser<'i> for PropertyDeclarationParser<'a, 'i> {
+impl<'a, 'o, 'i> AtRuleParser<'i> for PropertyDeclarationParser<'a, 'o, 'i> {
   type Prelude = ();
   type AtRule = ();
   type Error = ParserError<'i>;

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -87,7 +87,7 @@ pub struct UrlDependency {
 impl UrlDependency {
   /// Creates a new url dependency.
   pub fn new(url: &Url, filename: &str) -> UrlDependency {
-    let placeholder = hash(&format!("{}_{}", filename, url.url));
+    let placeholder = hash(&format!("{}_{}", filename, url.url), false);
     UrlDependency {
       url: url.url.to_string(),
       placeholder,

--- a/src/error.rs
+++ b/src/error.rs
@@ -345,6 +345,8 @@ pub enum PrinterErrorKind {
   InvalidComposesNesting,
   /// The CSS modules `composes` property cannot be used with a simple class selector.
   InvalidComposesSelector,
+  /// The CSS modules pattern must end with `[local]` for use in CSS grid.
+  InvalidCssModulesPatternInGrid,
 }
 
 impl From<fmt::Error> for PrinterError {
@@ -364,6 +366,7 @@ impl fmt::Display for PrinterErrorKind {
       FmtError => write!(f, "Printer error"),
       InvalidComposesNesting => write!(f, "The `composes` property cannot be used within nested rules"),
       InvalidComposesSelector => write!(f, "The `composes` property cannot be used with a simple class selector"),
+      InvalidCssModulesPatternInGrid => write!(f, "The CSS modules `pattern` config must end with `[local]` for use in CSS grid line names."),
     }
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16124,6 +16124,35 @@ mod tests {
         pattern: crate::css_modules::Pattern::parse("test-[hash]-[local]").unwrap(),
       },
     );
+
+    let stylesheet = StyleSheet::parse(
+      "test.css",
+      r#"
+        .grid {
+          grid-template-areas: "foo";
+        }
+
+        .foo {
+          grid-area: foo;
+        }
+
+        .bar {
+          grid-column-start: foo-start;
+        }
+      "#,
+      ParserOptions {
+        css_modules: Some(crate::css_modules::Config {
+          pattern: crate::css_modules::Pattern::parse("test-[local]-[hash]").unwrap(),
+        }),
+        ..ParserOptions::default()
+      },
+    )
+    .unwrap();
+    if let Err(err) = stylesheet.to_css(PrinterOptions::default()) {
+      assert_eq!(err.kind, PrinterErrorKind::InvalidCssModulesPatternInGrid);
+    } else {
+      unreachable!()
+    }
   }
 
   #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17903,14 +17903,14 @@ mod tests {
 
     dep_test(
       ".foo { background: image-set('./img12x.png', './img21x.png' 2x)}",
-      ".foo{background:image-set(\"hXFI8W\",\"_5TkpBa\" 2x)}",
-      vec![("./img12x.png", "hXFI8W"), ("./img21x.png", "_5TkpBa")],
+      ".foo{background:image-set(\"hXFI8W\",\"5TkpBa\" 2x)}",
+      vec![("./img12x.png", "hXFI8W"), ("./img21x.png", "5TkpBa")],
     );
 
     dep_test(
       ".foo { background: image-set(url(./img12x.png), url('./img21x.png') 2x)}",
-      ".foo{background:image-set(\"hXFI8W\",\"_5TkpBa\" 2x)}",
-      vec![("./img12x.png", "hXFI8W"), ("./img21x.png", "_5TkpBa")],
+      ".foo{background:image-set(\"hXFI8W\",\"5TkpBa\" 2x)}",
+      vec![("./img12x.png", "hXFI8W"), ("./img21x.png", "5TkpBa")],
     );
 
     dep_test(
@@ -17927,8 +17927,8 @@ mod tests {
 
     dep_test(
       ".foo { --test: url(\"http://example.com/foo.png\") }",
-      ".foo{--test:url(\"_3X1zSW\")}",
-      vec![("http://example.com/foo.png", "_3X1zSW")],
+      ".foo{--test:url(\"3X1zSW\")}",
+      vec![("http://example.com/foo.png", "3X1zSW")],
     );
 
     dep_test(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,12 +151,17 @@ mod tests {
     assert_eq!(res.code, expected);
   }
 
-  fn css_modules_test(source: &str, expected: &str, expected_exports: CssModuleExports) {
+  fn css_modules_test<'i>(
+    source: &'i str,
+    expected: &str,
+    expected_exports: CssModuleExports,
+    config: crate::css_modules::Config<'i>,
+  ) {
     let mut stylesheet = StyleSheet::parse(
       "test.css",
       &source,
       ParserOptions {
-        css_modules: true,
+        css_modules: Some(config),
         ..ParserOptions::default()
       },
     )
@@ -15774,6 +15779,7 @@ mod tests {
         "circles" => "EgL3uq_circles" referenced: true,
         "fade" => "EgL3uq_fade"
       },
+      Default::default(),
     );
 
     #[cfg(feature = "grid")]
@@ -15816,6 +15822,7 @@ mod tests {
         "a" => "EgL3uq_a",
         "b" => "EgL3uq_b"
       },
+      Default::default(),
     );
 
     #[cfg(feature = "grid")]
@@ -15852,6 +15859,7 @@ mod tests {
         "grid" => "EgL3uq_grid",
         "bar" => "EgL3uq_bar"
       },
+      Default::default(),
     );
 
     css_modules_test(
@@ -15866,6 +15874,7 @@ mod tests {
       }
     "#},
       map! {},
+      Default::default(),
     );
 
     css_modules_test(
@@ -15898,6 +15907,7 @@ mod tests {
       map! {
         "bar" => "EgL3uq_bar"
       },
+      Default::default(),
     );
 
     // :global(:local(.hi)) {
@@ -15928,6 +15938,7 @@ mod tests {
         "test" => "EgL3uq_test" "EgL3uq_foo",
         "foo" => "EgL3uq_foo"
       },
+      Default::default(),
     );
 
     css_modules_test(
@@ -15955,6 +15966,7 @@ mod tests {
         "b" => "EgL3uq_b" "EgL3uq_foo",
         "foo" => "EgL3uq_foo"
       },
+      Default::default(),
     );
 
     css_modules_test(
@@ -15990,6 +16002,7 @@ mod tests {
         "foo" => "EgL3uq_foo",
         "bar" => "EgL3uq_bar"
       },
+      Default::default(),
     );
 
     css_modules_test(
@@ -16007,6 +16020,7 @@ mod tests {
       map! {
         "test" => "EgL3uq_test" "foo" global: true
       },
+      Default::default(),
     );
 
     css_modules_test(
@@ -16024,6 +16038,7 @@ mod tests {
       map! {
         "test" => "EgL3uq_test" "foo" global: true "bar" global: true
       },
+      Default::default(),
     );
 
     css_modules_test(
@@ -16041,6 +16056,7 @@ mod tests {
       map! {
         "test" => "EgL3uq_test" "foo" from "foo.css"
       },
+      Default::default(),
     );
 
     css_modules_test(
@@ -16058,6 +16074,7 @@ mod tests {
       map! {
         "test" => "EgL3uq_test" "foo" from "foo.css" "bar" from "foo.css"
       },
+      Default::default(),
     );
 
     css_modules_test(
@@ -16085,6 +16102,26 @@ mod tests {
       map! {
         "test" => "EgL3uq_test" "EgL3uq_foo" "foo" from "foo.css" "bar" from "bar.css",
         "foo" => "EgL3uq_foo"
+      },
+      Default::default(),
+    );
+
+    css_modules_test(
+      r#"
+      .foo {
+        color: red;
+      }
+    "#,
+      indoc! {r#"
+      .test-EgL3uq-foo {
+        color: red;
+      }
+    "#},
+      map! {
+        "foo" => "test-EgL3uq-foo"
+      },
+      crate::css_modules::Config {
+        pattern: crate::css_modules::Pattern::parse("test-[hash]-[local]").unwrap(),
       },
     );
   }
@@ -16149,7 +16186,7 @@ mod tests {
       "test.css",
       &source,
       ParserOptions {
-        css_modules: true,
+        css_modules: Some(Default::default()),
         ..ParserOptions::default()
       },
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ pub fn main() -> Result<(), std::io::Error> {
   let filename = filename.to_str().unwrap();
   let options = ParserOptions {
     nesting: cli_args.nesting,
-    css_modules: cli_args.css_modules.is_some(),
+    css_modules: cli_args.css_modules.as_ref().map(|_| Default::default()),
     custom_media: cli_args.custom_media,
     ..ParserOptions::default()
   };

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -61,7 +61,7 @@ pub struct Printer<'a, 'b, 'c, W> {
   pub(crate) sources: Option<&'c Vec<String>>,
   dest: &'a mut W,
   source_map: Option<&'a mut SourceMap>,
-  pub(crate) source_index: u32,
+  pub(crate) loc: Location,
   indent: u8,
   line: u32,
   col: u32,
@@ -83,7 +83,11 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> Printer<'a, 'b, 'c, W> {
       sources: None,
       dest,
       source_map: options.source_map,
-      source_index: 0,
+      loc: Location {
+        source_index: 0,
+        line: 0,
+        column: 1,
+      },
       indent: 0,
       line: 0,
       col: 0,
@@ -104,7 +108,7 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> Printer<'a, 'b, 'c, W> {
   /// Returns the current source filename that is being printed.
   pub fn filename(&self) -> &'c str {
     if let Some(sources) = self.sources {
-      if let Some(f) = sources.get(self.source_index as usize) {
+      if let Some(f) = sources.get(self.loc.source_index as usize) {
         f
       } else {
         "unknown.css"
@@ -200,7 +204,7 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> Printer<'a, 'b, 'c, W> {
 
   /// Adds a mapping to the source map, if any.
   pub fn add_mapping(&mut self, loc: Location) {
-    self.source_index = loc.source_index;
+    self.loc = loc;
     if let Some(map) = &mut self.source_map {
       map.add_mapping(
         self.line,

--- a/src/properties/mod.rs
+++ b/src/properties/mod.rs
@@ -547,7 +547,7 @@ macro_rules! define_properties {
         match property_id {
           $(
             $(#[$meta])*
-            PropertyId::$property$((vp_name!($vp, prefix)))? $(if options.$condition)? => {
+            PropertyId::$property$((vp_name!($vp, prefix)))? $(if options.$condition.is_some())? => {
               if let Ok(c) = <$type>::parse(input) {
                 if input.expect_exhausted().is_ok() {
                   return Ok(Property::$property(c $(, vp_name!($vp, prefix))?))

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -197,14 +197,17 @@ impl<'i> CssRule<'i> {
   /// Parse a single rule.
   pub fn parse<'t>(
     input: &mut Parser<'i, 't>,
-    options: &ParserOptions,
+    options: &ParserOptions<'i>,
   ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
     let (_, rule) = parse_one_rule(input, &mut TopLevelRuleParser::new(&options))?;
     Ok(rule)
   }
 
   /// Parse a single rule from a string.
-  pub fn parse_string(input: &'i str, options: ParserOptions) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+  pub fn parse_string(
+    input: &'i str,
+    options: ParserOptions<'i>,
+  ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
     let mut input = ParserInput::new(input);
     let mut parser = Parser::new(&mut input);
     Self::parse(&mut parser, &options)

--- a/src/stylesheet.rs
+++ b/src/stylesheet.rs
@@ -58,7 +58,7 @@ pub use crate::printer::PseudoClasses;
 /// ```
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct StyleSheet<'i> {
+pub struct StyleSheet<'i, 'o> {
   /// A list of top-level rules within the style sheet.
   #[cfg_attr(feature = "serde", serde(borrow))]
   pub rules: CssRuleList<'i>,
@@ -67,7 +67,7 @@ pub struct StyleSheet<'i> {
   pub sources: Vec<String>,
   #[cfg_attr(feature = "serde", serde(skip))]
   /// The options the style sheet was originally parsed with.
-  options: ParserOptions,
+  options: ParserOptions<'o>,
 }
 
 /// Options for the `minify` function of a [StyleSheet](StyleSheet)
@@ -94,9 +94,9 @@ pub struct ToCssResult {
   pub dependencies: Option<Vec<Dependency>>,
 }
 
-impl<'i> StyleSheet<'i> {
+impl<'i, 'o> StyleSheet<'i, 'o> {
   /// Creates a new style sheet with the given source filenames and rules.
-  pub fn new(sources: Vec<String>, rules: CssRuleList, options: ParserOptions) -> StyleSheet {
+  pub fn new(sources: Vec<String>, rules: CssRuleList<'i>, options: ParserOptions<'o>) -> StyleSheet<'i, 'o> {
     StyleSheet {
       sources,
       rules,
@@ -105,11 +105,7 @@ impl<'i> StyleSheet<'i> {
   }
 
   /// Parse a style sheet from a string.
-  pub fn parse(
-    filename: &str,
-    code: &'i str,
-    options: ParserOptions,
-  ) -> Result<StyleSheet<'i>, Error<ParserError<'i>>> {
+  pub fn parse(filename: &str, code: &'i str, options: ParserOptions<'o>) -> Result<Self, Error<ParserError<'i>>> {
     let filename = String::from(filename);
     let mut input = ParserInput::new(&code);
     let mut parser = Parser::new(&mut input);
@@ -184,11 +180,12 @@ impl<'i> StyleSheet<'i> {
 
     printer.sources = Some(&self.sources);
 
-    if self.options.css_modules {
+    if let Some(config) = &self.options.css_modules {
       let h = hash(printer.filename());
       let mut exports = HashMap::new();
       printer.css_module = Some(CssModule {
-        hash: &h,
+        config,
+        hash: h,
         exports: &mut exports,
       });
 

--- a/src/stylesheet.rs
+++ b/src/stylesheet.rs
@@ -5,7 +5,7 @@
 
 use crate::compat::Feature;
 use crate::context::{DeclarationContext, PropertyHandlerContext};
-use crate::css_modules::{hash, CssModule, CssModuleExports};
+use crate::css_modules::{CssModule, CssModuleExports};
 use crate::declaration::{DeclarationBlock, DeclarationHandler};
 use crate::dependencies::Dependency;
 use crate::error::{Error, ErrorLocation, MinifyErrorKind, ParserError, PrinterError, PrinterErrorKind};
@@ -181,13 +181,8 @@ impl<'i, 'o> StyleSheet<'i, 'o> {
     printer.sources = Some(&self.sources);
 
     if let Some(config) = &self.options.css_modules {
-      let h = hash(printer.filename());
       let mut exports = HashMap::new();
-      printer.css_module = Some(CssModule {
-        config,
-        hash: h,
-        exports: &mut exports,
-      });
+      printer.css_module = Some(CssModule::new(config, printer.filename(), &mut exports));
 
       self.rules.to_css(&mut printer)?;
       printer.newline()?;

--- a/test.js
+++ b/test.js
@@ -37,26 +37,21 @@ let res = css.transform({
     opera: 10 << 16 | 5 << 8
   },
   code: Buffer.from(`
-  @import "foo.css";
-  @import "bar.css" print;
-  @import "baz.css" supports(display: grid);
-
   .foo {
-    composes: bar;
-    composes: baz from "baz.css";
     color: pink;
   }
 
   .bar {
     color: red;
-    background: url(test.jpg);
   }
 `),
   drafts: {
-    nesting: true
+    // nesting: true
   },
-  cssModules: true,
-  analyzeDependencies: true
+  cssModules: {
+    pattern: '[name]-[hash]-[local]'
+  },
+  // analyzeDependencies: true
 });
 
 console.log(res.code.toString());


### PR DESCRIPTION
Closes #156.

This adds support for custom patterns for generating names in css modules. Using `cssModules: true` continues to use the same default pattern as before, but you can also now set it to a config object:

```js
{
  cssModules: {
    pattern: 'library-[name]-[hash]-[local]
  }
}
```

The currently supported segments are:

* `[name]` - the base name of the file name being transformed, without the extension
* `[hash]` - a hash of the full file path
* `[local]` - the original class name

We could add more if needed as well. The pattern is parsed ahead of time and interpreted when writing out class names. Hopefully this solves the majority of use cases. We could add a JS callback for this as well, but it would add a lot of performance overhead so I would like to avoid it if possible.