### PR TITLE
Add support for system-ui fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A CSS parser, transformer, and minifier written in Rust.
   - Two-value `overflow` shorthand
   - Media query range syntax (e.g. `@media (width <= 100px)` or `@media (100px < width < 500px)`)
   - Multi-value `display` property (e.g. `inline flex`)
+  - `system-ui` font family fallbacks
 - **CSS modules** – `@parcel/css` supports compiling a subset of [CSS modules](https://github.com/css-modules/css-modules) features.
   - Locally scoped class and id selectors
   - Locally scoped custom identifiers, e.g. `@keyframes` names, grid lines/areas, `@counter-style` names, etc.

--- a/scripts/build-prefixes.js
+++ b/scripts/build-prefixes.js
@@ -168,7 +168,8 @@ let cssFeatures = [
   'css-rrggbbaa',
   'css-nesting',
   'css-not-sel-list',
-  'css-has'
+  'css-has',
+  'font-family-system-ui'
 ];
 
 let compat = new Map();
@@ -315,11 +316,12 @@ use serde::{Deserialize, Serialize};
 /// use parcel_css::targets::Browsers;
 ///
 /// let targets = Browsers {
-///   safari: (13 << 16) | (2 << 8),
+///   safari: Some((13 << 16) | (2 << 8)),
 ///   ..Browsers::default()
 /// };
 /// \`\`\`
 #[derive(Serialize, Debug, Deserialize, Clone, Copy, Default)]
+#[allow(missing_docs)]
 pub struct Browsers {
   pub ${allBrowsers.join(': Option<u32>,\n  pub ')}: Option<u32>
 }

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -36,6 +36,7 @@ pub enum Feature {
   CustomMediaQueries,
   Dialog,
   DoublePositionGradients,
+  FontFamilySystemUi,
   FormValidation,
   Fullscreen,
   LabColors,
@@ -1269,6 +1270,51 @@ impl Feature {
           || browsers.opera.is_some()
           || browsers.samsung.is_some()
         {
+          return false;
+        }
+      }
+      Feature::FontFamilySystemUi => {
+        if let Some(version) = browsers.edge {
+          if version < 5177344 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.firefox {
+          if version < 6029312 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.chrome {
+          if version < 3670016 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.safari {
+          if version < 720896 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.opera {
+          if version < 2818048 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.ios_saf {
+          if version < 720896 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.android {
+          if version < 6553600 {
+            return false;
+          }
+        }
+        if let Some(version) = browsers.samsung {
+          if version < 393728 {
+            return false;
+          }
+        }
+        if browsers.ie.is_some() {
           return false;
         }
       }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4686,6 +4686,42 @@ mod tests {
       "@font-face { font-family: 'revert-layer'; }",
       "@font-face{font-family:\"revert-layer\"}",
     );
+
+    prefix_test(
+      r#"
+      .foo {
+        font-family: Helvetica, system-ui, sans-serif;
+      }
+    "#,
+      indoc! {r#"
+      .foo {
+        font-family: Helvetica, system-ui, AppleSystem, BlinkMacSystemFont, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
+      }
+    "#
+      },
+      Browsers {
+        safari: Some(8 << 16),
+        ..Browsers::default()
+      },
+    );
+
+    prefix_test(
+      r#"
+      .foo {
+        font: 100%/1.5 Helvetica, system-ui, sans-serif;
+      }
+    "#,
+      indoc! {r#"
+      .foo {
+        font: 100% / 1.5 Helvetica, system-ui, AppleSystem, BlinkMacSystemFont, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
+      }
+    "#
+      },
+      Browsers {
+        safari: Some(8 << 16),
+        ..Browsers::default()
+      },
+    );
   }
 
   #[test]


### PR DESCRIPTION
The `system-ui` font family is a special font family that will be changed to the platform's default font family.

This feature will add fallback font families when unsupported

```css
.foo {
  font-family: Helvetica, system-ui, sans-serif;
}

.bar {
  font: 100%/1.5 Helvetica, system-ui, sans-serif;
}
```

becomes

```css
.foo {
  font-family: Helvetica, system-ui, AppleSystem, BlinkMacSystemFont, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
}

.bar {
  font: 100% / 1.5 Helvetica, system-ui, AppleSystem, BlinkMacSystemFont, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
}
```

The list of fonts comes from this postcss plugin: https://www.npmjs.com/package/postcss-font-family-system-ui

These are my very first lines of Rust, I'm open to feedback if something isn't idiomatic or could be made more efficiently or anything really :)