### PR TITLE
Support for hashing CSS variables

### DIFF
--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -1,4 +1,4 @@
-import type {Targets} from './targets';
+import type { Targets } from './targets';
 
 export interface TransformOptions {
   /** The filename being transformed. Used for error messages and source maps. */
@@ -14,7 +14,7 @@ export interface TransformOptions {
   /** Whether to enable various draft syntax. */
   drafts?: Drafts,
   /** Whether to compile this file as a CSS module. */
-  cssModules?: boolean,
+  cssModules?: boolean | CSSModulesConfig,
   /**
    * Whether to analyze dependencies (e.g. `@import` and `url()`).
    * When enabled, `@import` rules are removed, and `url()` dependencies
@@ -61,6 +61,13 @@ export interface TransformResult {
   exports: CSSModuleExports | void,
   /** `@import` and `url()` dependencies, if enabled. */
   dependencies: Dependency[] | void
+}
+
+export interface CSSModulesConfig {
+  /** The pattern to use when renaming class names and other identifiers. Default is `[hash]_[local]`. */
+  pattern: string,
+  /** Whether to rename dashed identifiers, e.g. custom properties. */
+  dashedIdents: boolean
 }
 
 export type CSSModuleExports = {
@@ -158,14 +165,14 @@ export interface TransformAttributeOptions {
    * that can be replaced with the final urls later (after bundling).
    * Dependencies are returned as part of the result.
    */
-   analyzeDependencies?: boolean
+  analyzeDependencies?: boolean
 }
 
 export interface TransformAttributeResult {
   /** The transformed code. */
   code: Buffer,
   /** `@import` and `url()` dependencies, if enabled. */
-  dependencies: Dependency[] | void  
+  dependencies: Dependency[] | void
 }
 
 /**

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -59,6 +59,8 @@ export interface TransformResult {
   map: Buffer | void,
   /** CSS module exports, if enabled. */
   exports: CSSModuleExports | void,
+  /** CSS module references, if `dashedIdents` is enabled. */
+  references: CSSModuleReferences,
   /** `@import` and `url()` dependencies, if enabled. */
   dependencies: Dependency[] | void
 }
@@ -83,6 +85,11 @@ export interface CSSModuleExport {
   /** Other names that are composed by this export. */
   composes: CSSModuleReference[]
 }
+
+export type CSSModuleReferences = {
+  /** Maps placeholder names to references. */
+  [name: string]: DependencyCSSModuleReference,
+};
 
 export type CSSModuleReference = LocalCSSModuleReference | GlobalCSSModuleReference | DependencyCSSModuleReference;
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use crate::compat::Feature;
 use crate::declaration::DeclarationBlock;
 use crate::properties::custom::UnparsedProperty;
@@ -25,17 +27,18 @@ pub(crate) enum DeclarationContext {
 }
 
 #[derive(Debug)]
-pub(crate) struct PropertyHandlerContext<'i> {
+pub(crate) struct PropertyHandlerContext<'i, 'o> {
   pub targets: Option<Browsers>,
   pub is_important: bool,
   supports: Vec<SupportsEntry<'i>>,
   ltr: Vec<Property<'i>>,
   rtl: Vec<Property<'i>>,
   pub context: DeclarationContext,
+  pub unused_symbols: &'o HashSet<String>,
 }
 
-impl<'i> PropertyHandlerContext<'i> {
-  pub fn new(targets: Option<Browsers>) -> Self {
+impl<'i, 'o> PropertyHandlerContext<'i, 'o> {
+  pub fn new(targets: Option<Browsers>, unused_symbols: &'o HashSet<String>) -> Self {
     PropertyHandlerContext {
       targets,
       is_important: false,
@@ -43,6 +46,7 @@ impl<'i> PropertyHandlerContext<'i> {
       ltr: Vec::new(),
       rtl: Vec::new(),
       context: DeclarationContext::None,
+      unused_symbols,
     }
   }
 

--- a/src/css_modules.rs
+++ b/src/css_modules.rs
@@ -9,7 +9,7 @@
 //! will be updated accordingly. A map of the original names to compiled (hashed) names will be returned.
 
 use crate::error::PrinterErrorKind;
-use crate::properties::css_modules::{Composes, ComposesFrom};
+use crate::properties::css_modules::{Composes, Specifier};
 use crate::selector::Selectors;
 use data_encoding::{Encoding, Specification};
 use lazy_static::lazy_static;
@@ -247,10 +247,10 @@ impl<'a, 'b, 'c> CssModule<'a, 'b, 'c> {
     }
   }
 
-  pub fn reference_dashed(&mut self, name: &str, from: &Option<ComposesFrom>) -> Option<String> {
+  pub fn reference_dashed(&mut self, name: &str, from: &Option<Specifier>) -> Option<String> {
     let (reference, key) = match from {
-      Some(ComposesFrom::Global) => return Some(name[2..].into()),
-      Some(ComposesFrom::File(file)) => (
+      Some(Specifier::Global) => return Some(name[2..].into()),
+      Some(Specifier::File(file)) => (
         CssModuleReference::Dependency {
           name: name.to_string(),
           specifier: file.to_string(),
@@ -304,10 +304,10 @@ impl<'a, 'b, 'c> CssModule<'a, 'b, 'c> {
                     .write_to_string(String::new(), &self.hash, &self.path, name.0.as_ref())
                     .unwrap(),
                 },
-                Some(ComposesFrom::Global) => CssModuleReference::Global {
+                Some(Specifier::Global) => CssModuleReference::Global {
                   name: name.0.as_ref().into(),
                 },
-                Some(ComposesFrom::File(file)) => CssModuleReference::Dependency {
+                Some(Specifier::File(file)) => CssModuleReference::Dependency {
                   name: name.0.to_string(),
                   specifier: file.to_string(),
                 },

--- a/src/css_modules.rs
+++ b/src/css_modules.rs
@@ -25,8 +25,11 @@ use std::path::Path;
 /// Configuration for CSS modules.
 #[derive(Default, Clone, Debug)]
 pub struct Config<'i> {
-  /// The class name pattern to use. Default is `[hash]_[local]`.
+  /// The name pattern to use when renaming class names and other identifiers.
+  /// Default is `[hash]_[local]`.
   pub pattern: Pattern<'i>,
+  /// Whether to rename dashed identifiers, e.g. custom properties.
+  pub dashed_idents: bool,
 }
 
 /// A CSS modules class name pattern.
@@ -96,8 +99,14 @@ impl<'i> Pattern<'i> {
     Ok(())
   }
 
-  fn write_to_string(&self, hash: &str, path: &Path, local: &str) -> Result<String, std::fmt::Error> {
-    let mut res = String::new();
+  #[inline]
+  fn write_to_string(
+    &self,
+    mut res: String,
+    hash: &str,
+    path: &Path,
+    local: &str,
+  ) -> Result<String, std::fmt::Error> {
     self.write(hash, path, local, |s| res.write_str(s))?;
     Ok(res)
   }
@@ -158,6 +167,9 @@ pub struct CssModuleExport {
 /// A map of exported names to values.
 pub type CssModuleExports = HashMap<String, CssModuleExport>;
 
+/// A map of placeholders to references.
+pub type CssModuleReferences = HashMap<String, CssModuleReference>;
+
 lazy_static! {
   static ref ENCODER: Encoding = {
     let mut spec = Specification::new();
@@ -173,21 +185,44 @@ pub(crate) struct CssModule<'a, 'b, 'c> {
   pub path: &'c Path,
   pub hash: String,
   pub exports: &'a mut CssModuleExports,
+  pub references: &'a mut HashMap<String, CssModuleReference>,
 }
 
 impl<'a, 'b, 'c> CssModule<'a, 'b, 'c> {
-  pub fn new(config: &'a Config<'b>, filename: &'c str, exports: &'a mut CssModuleExports) -> Self {
+  pub fn new(
+    config: &'a Config<'b>,
+    filename: &'c str,
+    exports: &'a mut CssModuleExports,
+    references: &'a mut HashMap<String, CssModuleReference>,
+  ) -> Self {
     Self {
       config,
       path: Path::new(filename),
       hash: hash(filename, matches!(config.pattern.segments[0], Segment::Hash)),
       exports,
+      references,
     }
   }
 
   pub fn add_local(&mut self, exported: &str, local: &str) {
     self.exports.entry(exported.into()).or_insert_with(|| CssModuleExport {
-      name: self.config.pattern.write_to_string(&self.hash, &self.path, local).unwrap(),
+      name: self
+        .config
+        .pattern
+        .write_to_string(String::new(), &self.hash, &self.path, local)
+        .unwrap(),
+      composes: vec![],
+      is_referenced: false,
+    });
+  }
+
+  pub fn add_dashed(&mut self, local: &str) {
+    self.exports.entry(local.into()).or_insert_with(|| CssModuleExport {
+      name: self
+        .config
+        .pattern
+        .write_to_string("--".into(), &self.hash, &self.path, &local[2..])
+        .unwrap(),
       composes: vec![],
       is_referenced: false,
     });
@@ -200,12 +235,55 @@ impl<'a, 'b, 'c> CssModule<'a, 'b, 'c> {
       }
       std::collections::hash_map::Entry::Vacant(entry) => {
         entry.insert(CssModuleExport {
-          name: self.config.pattern.write_to_string(&self.hash, &self.path, name).unwrap(),
+          name: self
+            .config
+            .pattern
+            .write_to_string(String::new(), &self.hash, &self.path, name)
+            .unwrap(),
           composes: vec![],
           is_referenced: true,
         });
       }
     }
+  }
+
+  pub fn reference_dashed(&mut self, name: &str, from: &Option<ComposesFrom>) -> Option<String> {
+    let (reference, key) = match from {
+      Some(ComposesFrom::Global) => (CssModuleReference::Global { name: name.into() }, "global"),
+      Some(ComposesFrom::File(file)) => (
+        CssModuleReference::Dependency {
+          name: name.to_string(),
+          specifier: file.to_string(),
+        },
+        file.as_ref(),
+      ),
+      None => {
+        // Local export. Mark as used.
+        match self.exports.entry(name.into()) {
+          std::collections::hash_map::Entry::Occupied(mut entry) => {
+            entry.get_mut().is_referenced = true;
+          }
+          std::collections::hash_map::Entry::Vacant(entry) => {
+            entry.insert(CssModuleExport {
+              name: self
+                .config
+                .pattern
+                .write_to_string("--".into(), &self.hash, &self.path, name)
+                .unwrap(),
+              composes: vec![],
+              is_referenced: true,
+            });
+          }
+        }
+        return None;
+      }
+    };
+
+    let hash = hash(&format!("{}_{}_{}", self.hash, name, key), false);
+    let name = format!("--{}", hash);
+
+    self.references.insert(name.clone(), reference);
+    Some(hash)
   }
 
   pub fn handle_composes(
@@ -223,7 +301,7 @@ impl<'a, 'b, 'c> CssModule<'a, 'b, 'c> {
                   name: self
                     .config
                     .pattern
-                    .write_to_string(&self.hash, &self.path, name.0.as_ref())
+                    .write_to_string(String::new(), &self.hash, &self.path, name.0.as_ref())
                     .unwrap(),
                 },
                 Some(ComposesFrom::Global) => CssModuleReference::Global {

--- a/src/css_modules.rs
+++ b/src/css_modules.rs
@@ -249,7 +249,7 @@ impl<'a, 'b, 'c> CssModule<'a, 'b, 'c> {
 
   pub fn reference_dashed(&mut self, name: &str, from: &Option<ComposesFrom>) -> Option<String> {
     let (reference, key) = match from {
-      Some(ComposesFrom::Global) => (CssModuleReference::Global { name: name.into() }, "global"),
+      Some(ComposesFrom::Global) => return Some(name[2..].into()),
       Some(ComposesFrom::File(file)) => (
         CssModuleReference::Dependency {
           name: name.to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16212,9 +16212,17 @@ mod tests {
         initial-value: yellow;
       }
 
+      @font-palette-values --Cooler {
+        font-family: Bixa;
+        base-palette: 1;
+        override-colors: 1 #7EB7E4;
+      }
+
       .foo {
         --foo: red;
+        --bar: green;
         color: var(--foo);
+        font-palette: --Cooler;
       }
 
       .bar {
@@ -16228,9 +16236,17 @@ mod tests {
         initial-value: #ff0;
       }
 
+      @font-palette-values --EgL3uq_Cooler {
+        font-family: Bixa;
+        base-palette: 1;
+        override-colors: 1 #7eb7e4;
+      }
+
       .EgL3uq_foo {
         --EgL3uq_foo: red;
+        --EgL3uq_bar: green;
         color: var(--EgL3uq_foo);
+        font-palette: --EgL3uq_Cooler;
       }
 
       .EgL3uq_bar {
@@ -16240,7 +16256,9 @@ mod tests {
       map! {
         "foo" => "EgL3uq_foo",
         "--foo" => "--EgL3uq_foo" referenced: true,
-        "bar" => "EgL3uq_bar"
+        "--bar" => "--EgL3uq_bar",
+        "bar" => "EgL3uq_bar",
+        "--Cooler" => "--EgL3uq_Cooler" referenced: true
       },
       HashMap::from([(
         "--ma1CsG".into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16533,6 +16533,12 @@ mod tests {
         initial-value: #ff0;
       }
 
+      @font-palette-values --EgL3uq_Cooler {
+        font-family: Bixa;
+        base-palette: 1;
+        override-colors: 1 #7EB7E4;
+      }
+
       .EgL3uq_foo {
         --EgL3uq_foo: red;
       }
@@ -16559,7 +16565,10 @@ mod tests {
     .unwrap();
     stylesheet
       .minify(MinifyOptions {
-        unused_symbols: vec!["--EgL3uq_foo"].iter().map(|s| String::from(*s)).collect(),
+        unused_symbols: vec!["--EgL3uq_foo", "--EgL3uq_Cooler"]
+          .iter()
+          .map(|s| String::from(*s))
+          .collect(),
         ..MinifyOptions::default()
       })
       .unwrap();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -231,7 +231,7 @@ macro_rules! shorthand_handler {
     }
 
     impl<'i> PropertyHandler<'i> for $name$(<$l>)? {
-      fn handle_property(&mut self, property: &Property<'i>, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i>) -> bool {
+      fn handle_property(&mut self, property: &Property<'i>, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i, '_>) -> bool {
         match property {
           $(
             Property::$prop(val) => {
@@ -258,7 +258,7 @@ macro_rules! shorthand_handler {
         true
       }
 
-      fn finalize(&mut self, dest: &mut DeclarationList<'i>, _: &mut PropertyHandlerContext<'i>) {
+      fn finalize(&mut self, dest: &mut DeclarationList<'i>, _: &mut PropertyHandlerContext<'i, '_>) {
         if !self.has_any {
           return
         }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -3,7 +3,6 @@
 use crate::css_modules::CssModule;
 use crate::dependencies::Dependency;
 use crate::error::{Error, ErrorLocation, PrinterError, PrinterErrorKind};
-use crate::properties::css_modules::ComposesFrom;
 use crate::rules::Location;
 use crate::targets::Browsers;
 use crate::vendor_prefix::VendorPrefix;
@@ -248,21 +247,11 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> Printer<'a, 'b, 'c, W> {
     Ok(())
   }
 
-  pub(crate) fn write_dashed_ident(
-    &mut self,
-    ident: &str,
-    from: Option<&Option<ComposesFrom>>,
-  ) -> Result<(), PrinterError> {
+  pub(crate) fn write_dashed_ident(&mut self, ident: &str, is_declaration: bool) -> Result<(), PrinterError> {
     self.write_str("--")?;
 
     match &mut self.css_module {
       Some(css_module) if css_module.config.dashed_idents => {
-        if let Some(from) = from {
-          if let Some(name) = css_module.reference_dashed(ident, from) {
-            serialize_name(&name, self)?;
-            return Ok(());
-          }
-        }
         let dest = &mut self.dest;
         css_module
           .config
@@ -272,7 +261,9 @@ impl<'a, 'b, 'c, W: std::fmt::Write + Sized> Printer<'a, 'b, 'c, W> {
             serialize_name(s, dest)
           })?;
 
-        css_module.add_dashed(ident);
+        if is_declaration {
+          css_module.add_dashed(ident);
+        }
       }
       _ => {
         serialize_name(&ident[2..], self)?;

--- a/src/properties/align.rs
+++ b/src/properties/align.rs
@@ -930,7 +930,7 @@ impl<'i> PropertyHandler<'i> for AlignHandler {
     &mut self,
     property: &Property<'i>,
     dest: &mut DeclarationList<'i>,
-    _: &mut PropertyHandlerContext<'i>,
+    _: &mut PropertyHandlerContext<'i, '_>,
   ) -> bool {
     use Property::*;
 
@@ -1037,7 +1037,7 @@ impl<'i> PropertyHandler<'i> for AlignHandler {
     true
   }
 
-  fn finalize(&mut self, dest: &mut DeclarationList, _: &mut PropertyHandlerContext<'i>) {
+  fn finalize(&mut self, dest: &mut DeclarationList, _: &mut PropertyHandlerContext<'i, '_>) {
     self.flush(dest);
   }
 }

--- a/src/properties/animation.rs
+++ b/src/properties/animation.rs
@@ -295,7 +295,7 @@ impl<'i> PropertyHandler<'i> for AnimationHandler<'i> {
     &mut self,
     property: &Property<'i>,
     dest: &mut DeclarationList<'i>,
-    _: &mut PropertyHandlerContext<'i>,
+    _: &mut PropertyHandlerContext<'i, '_>,
   ) -> bool {
     use Property::*;
 
@@ -379,7 +379,7 @@ impl<'i> PropertyHandler<'i> for AnimationHandler<'i> {
     true
   }
 
-  fn finalize(&mut self, dest: &mut DeclarationList<'i>, _: &mut PropertyHandlerContext<'i>) {
+  fn finalize(&mut self, dest: &mut DeclarationList<'i>, _: &mut PropertyHandlerContext<'i, '_>) {
     self.flush(dest);
   }
 }

--- a/src/properties/background.rs
+++ b/src/properties/background.rs
@@ -776,7 +776,7 @@ impl<'i> PropertyHandler<'i> for BackgroundHandler<'i> {
     &mut self,
     property: &Property<'i>,
     dest: &mut DeclarationList<'i>,
-    context: &mut PropertyHandlerContext<'i>,
+    context: &mut PropertyHandlerContext<'i, '_>,
   ) -> bool {
     macro_rules! background_image {
       ($val: ident) => {
@@ -841,7 +841,7 @@ impl<'i> PropertyHandler<'i> for BackgroundHandler<'i> {
     true
   }
 
-  fn finalize(&mut self, dest: &mut DeclarationList<'i>, _: &mut PropertyHandlerContext<'i>) {
+  fn finalize(&mut self, dest: &mut DeclarationList<'i>, _: &mut PropertyHandlerContext<'i, '_>) {
     // If the last declaration is prefixed, pop the last value
     // so it isn't duplicated when we flush.
     if self.has_prefix {

--- a/src/properties/border.rs
+++ b/src/properties/border.rs
@@ -535,7 +535,7 @@ impl<'i> PropertyHandler<'i> for BorderHandler<'i> {
     &mut self,
     property: &Property<'i>,
     dest: &mut DeclarationList<'i>,
-    context: &mut PropertyHandlerContext<'i>,
+    context: &mut PropertyHandlerContext<'i, '_>,
   ) -> bool {
     use Property::*;
 
@@ -687,7 +687,7 @@ impl<'i> PropertyHandler<'i> for BorderHandler<'i> {
     true
   }
 
-  fn finalize(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i>) {
+  fn finalize(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i, '_>) {
     self.flush(dest, context);
     self.border_image_handler.finalize(dest, context);
     self.border_radius_handler.finalize(dest, context);
@@ -695,7 +695,7 @@ impl<'i> PropertyHandler<'i> for BorderHandler<'i> {
 }
 
 impl<'i> BorderHandler<'i> {
-  fn flush(&mut self, dest: &mut DeclarationList, context: &mut PropertyHandlerContext<'i>) {
+  fn flush(&mut self, dest: &mut DeclarationList, context: &mut PropertyHandlerContext<'i, '_>) {
     if !self.has_any {
       return;
     }
@@ -1221,7 +1221,7 @@ impl<'i> BorderHandler<'i> {
     &mut self,
     unparsed: &UnparsedProperty<'i>,
     dest: &mut DeclarationList<'i>,
-    context: &mut PropertyHandlerContext<'i>,
+    context: &mut PropertyHandlerContext<'i, '_>,
   ) {
     let logical_supported = context.is_supported(Feature::LogicalBorders);
     if logical_supported {

--- a/src/properties/border_image.rs
+++ b/src/properties/border_image.rs
@@ -369,7 +369,7 @@ impl<'i> PropertyHandler<'i> for BorderImageHandler<'i> {
     &mut self,
     property: &Property<'i>,
     dest: &mut DeclarationList<'i>,
-    context: &mut PropertyHandlerContext<'i>,
+    context: &mut PropertyHandlerContext<'i, '_>,
   ) -> bool {
     use Property::*;
     macro_rules! property {
@@ -414,7 +414,7 @@ impl<'i> PropertyHandler<'i> for BorderImageHandler<'i> {
     true
   }
 
-  fn finalize(&mut self, dest: &mut DeclarationList<'i>, _: &mut PropertyHandlerContext<'i>) {
+  fn finalize(&mut self, dest: &mut DeclarationList<'i>, _: &mut PropertyHandlerContext<'i, '_>) {
     self.flush(dest);
   }
 }

--- a/src/properties/border_radius.rs
+++ b/src/properties/border_radius.rs
@@ -117,7 +117,7 @@ impl<'i> PropertyHandler<'i> for BorderRadiusHandler<'i> {
     &mut self,
     property: &Property<'i>,
     dest: &mut DeclarationList<'i>,
-    context: &mut PropertyHandlerContext<'i>,
+    context: &mut PropertyHandlerContext<'i, '_>,
   ) -> bool {
     use Property::*;
 
@@ -211,13 +211,13 @@ impl<'i> PropertyHandler<'i> for BorderRadiusHandler<'i> {
     true
   }
 
-  fn finalize(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i>) {
+  fn finalize(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i, '_>) {
     self.flush(dest, context);
   }
 }
 
 impl<'i> BorderRadiusHandler<'i> {
-  fn flush(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i>) {
+  fn flush(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i, '_>) {
     if !self.has_any {
       return;
     }

--- a/src/properties/box_shadow.rs
+++ b/src/properties/box_shadow.rs
@@ -136,7 +136,7 @@ impl<'i> PropertyHandler<'i> for BoxShadowHandler {
     &mut self,
     property: &Property<'i>,
     dest: &mut DeclarationList<'i>,
-    context: &mut PropertyHandlerContext<'i>,
+    context: &mut PropertyHandlerContext<'i, '_>,
   ) -> bool {
     match property {
       Property::BoxShadow(box_shadows, prefix) => {
@@ -165,7 +165,7 @@ impl<'i> PropertyHandler<'i> for BoxShadowHandler {
     true
   }
 
-  fn finalize(&mut self, dest: &mut DeclarationList, _: &mut PropertyHandlerContext<'i>) {
+  fn finalize(&mut self, dest: &mut DeclarationList, _: &mut PropertyHandlerContext<'i, '_>) {
     if self.box_shadows.is_none() {
       return;
     }

--- a/src/properties/display.rs
+++ b/src/properties/display.rs
@@ -387,7 +387,7 @@ impl<'i> PropertyHandler<'i> for DisplayHandler<'i> {
     &mut self,
     property: &Property<'i>,
     dest: &mut DeclarationList<'i>,
-    context: &mut PropertyHandlerContext<'i>,
+    context: &mut PropertyHandlerContext<'i, '_>,
   ) -> bool {
     if let Property::Display(display) = property {
       match (&self.display, display) {
@@ -431,7 +431,7 @@ impl<'i> PropertyHandler<'i> for DisplayHandler<'i> {
     false
   }
 
-  fn finalize(&mut self, dest: &mut DeclarationList<'i>, _: &mut PropertyHandlerContext<'i>) {
+  fn finalize(&mut self, dest: &mut DeclarationList<'i>, _: &mut PropertyHandlerContext<'i, '_>) {
     if self.display.is_none() {
       return;
     }

--- a/src/properties/flex.rs
+++ b/src/properties/flex.rs
@@ -491,7 +491,7 @@ impl<'i> PropertyHandler<'i> for FlexHandler {
     &mut self,
     property: &Property<'i>,
     dest: &mut DeclarationList<'i>,
-    _: &mut PropertyHandlerContext<'i>,
+    _: &mut PropertyHandlerContext<'i, '_>,
   ) -> bool {
     use Property::*;
 
@@ -603,7 +603,7 @@ impl<'i> PropertyHandler<'i> for FlexHandler {
     true
   }
 
-  fn finalize(&mut self, dest: &mut DeclarationList, _: &mut PropertyHandlerContext<'i>) {
+  fn finalize(&mut self, dest: &mut DeclarationList, _: &mut PropertyHandlerContext<'i, '_>) {
     self.flush(dest);
   }
 }

--- a/src/properties/font.rs
+++ b/src/properties/font.rs
@@ -793,7 +793,7 @@ impl<'i> PropertyHandler<'i> for FontHandler<'i> {
     &mut self,
     property: &Property<'i>,
     dest: &mut DeclarationList<'i>,
-    context: &mut PropertyHandlerContext<'i>,
+    context: &mut PropertyHandlerContext<'i, '_>,
   ) -> bool {
     use Property::*;
 
@@ -833,7 +833,7 @@ impl<'i> PropertyHandler<'i> for FontHandler<'i> {
     true
   }
 
-  fn finalize(&mut self, decls: &mut DeclarationList<'i>, _: &mut PropertyHandlerContext<'i>) {
+  fn finalize(&mut self, decls: &mut DeclarationList<'i>, _: &mut PropertyHandlerContext<'i, '_>) {
     if !self.has_any {
       return;
     }

--- a/src/properties/grid.rs
+++ b/src/properties/grid.rs
@@ -1506,7 +1506,7 @@ impl<'i> PropertyHandler<'i> for GridHandler<'i> {
     &mut self,
     property: &Property<'i>,
     dest: &mut DeclarationList<'i>,
-    context: &mut PropertyHandlerContext<'i>,
+    context: &mut PropertyHandlerContext<'i, '_>,
   ) -> bool {
     use Property::*;
 
@@ -1559,7 +1559,7 @@ impl<'i> PropertyHandler<'i> for GridHandler<'i> {
     true
   }
 
-  fn finalize(&mut self, dest: &mut DeclarationList<'i>, _: &mut PropertyHandlerContext<'i>) {
+  fn finalize(&mut self, dest: &mut DeclarationList<'i>, _: &mut PropertyHandlerContext<'i, '_>) {
     if !self.has_any {
       return;
     }

--- a/src/properties/margin_padding.rs
+++ b/src/properties/margin_padding.rs
@@ -177,7 +177,7 @@ macro_rules! side_handler {
     }
 
     impl<'i> PropertyHandler<'i> for $name<'i> {
-      fn handle_property(&mut self, property: &Property<'i>, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i>) -> bool {
+      fn handle_property(&mut self, property: &Property<'i>, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i, '_>) -> bool {
         use Property::*;
 
         macro_rules! property {
@@ -252,13 +252,13 @@ macro_rules! side_handler {
         true
       }
 
-      fn finalize(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i>) {
+      fn finalize(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i, '_>) {
         self.flush(dest, context);
       }
     }
 
     impl<'i> $name<'i> {
-      fn flush(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i>) {
+      fn flush(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i, '_>) {
         if !self.has_any {
           return
         }

--- a/src/properties/masking.rs
+++ b/src/properties/masking.rs
@@ -560,7 +560,7 @@ impl<'i> PropertyHandler<'i> for MaskHandler<'i> {
     &mut self,
     property: &Property<'i>,
     dest: &mut DeclarationList<'i>,
-    context: &mut PropertyHandlerContext<'i>,
+    context: &mut PropertyHandlerContext<'i, '_>,
   ) -> bool {
     macro_rules! maybe_flush {
       ($prop: ident, $val: expr, $vp: expr) => {{
@@ -704,7 +704,7 @@ impl<'i> PropertyHandler<'i> for MaskHandler<'i> {
     true
   }
 
-  fn finalize(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i>) {
+  fn finalize(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i, '_>) {
     if !self.has_any {
       return;
     }
@@ -717,7 +717,7 @@ impl<'i> PropertyHandler<'i> for MaskHandler<'i> {
 }
 
 impl<'i> MaskHandler<'i> {
-  fn flush_mask(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i>) {
+  fn flush_mask(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i, '_>) {
     let mut images = std::mem::take(&mut self.images);
     let mut positions = std::mem::take(&mut self.positions);
     let mut sizes = std::mem::take(&mut self.sizes);
@@ -963,7 +963,7 @@ impl<'i> MaskHandler<'i> {
     }
   }
 
-  fn flush_mask_border(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i>) {
+  fn flush_mask_border(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i, '_>) {
     let mut source = std::mem::take(&mut self.border_source);
     let mut slice = std::mem::take(&mut self.border_slice);
     let mut width = std::mem::take(&mut self.border_width);

--- a/src/properties/mod.rs
+++ b/src/properties/mod.rs
@@ -127,12 +127,12 @@ use crate::parser::ParserOptions;
 use crate::prefixes::Feature;
 use crate::printer::{Printer, PrinterOptions};
 use crate::targets::Browsers;
-use crate::traits::{Parse, Shorthand, ToCss};
+use crate::traits::{Parse, ParseWithOptions, Shorthand, ToCss};
 use crate::values::number::{CSSInteger, CSSNumber};
 use crate::values::string::CowArcStr;
 use crate::values::{
-  alpha::*, color::*, easing::EasingFunction, ident::DashedIdent, image::*, length::*, position::*, rect::*,
-  shape::FillRule, size::Size2D, time::Time,
+  alpha::*, color::*, easing::EasingFunction, ident::DashedIdentReference, image::*, length::*, position::*,
+  rect::*, shape::FillRule, size::Size2D, time::Time,
 };
 use crate::vendor_prefix::VendorPrefix;
 use align::*;
@@ -168,7 +168,7 @@ macro_rules! define_properties {
   (
     $(
       $(#[$meta: meta])*
-      $name: literal: $property: ident($type: ty $(, $vp: ty)?) $( / $prefix: ident )* $( unprefixed: $unprefixed: literal )? $( shorthand: $shorthand: literal )? $( [ logical_group: $logical_group: ident, category: $logical_category: ident ] )? $( if $condition: ident )?,
+      $name: literal: $property: ident($type: ty $(, $vp: ty)?) $( / $prefix: ident )* $( unprefixed: $unprefixed: literal )? $( options: $options: literal )? $( shorthand: $shorthand: literal )? $( [ logical_group: $logical_group: ident, category: $logical_category: ident ] )? $( if $condition: ident )?,
     )+
   ) => {
     /// A CSS property id.
@@ -548,7 +548,7 @@ macro_rules! define_properties {
           $(
             $(#[$meta])*
             PropertyId::$property$((vp_name!($vp, prefix)))? $(if options.$condition.is_some())? => {
-              if let Ok(c) = <$type>::parse(input) {
+              if let Ok(c) = <$type>::parse_with_options(input, options) {
                 if input.expect_exhausted().is_ok() {
                   return Ok(Property::$property(c $(, vp_name!($vp, prefix))?))
                 }
@@ -663,7 +663,7 @@ macro_rules! define_properties {
             // Ensure custom property names are escaped.
             let name = custom.name.as_ref();
             if name.starts_with("--") {
-              dest.write_dashed_ident(&name, None)?;
+              dest.write_dashed_ident(&name, true)?;
             } else {
               serialize_name(&name, dest)?;
             }
@@ -1010,7 +1010,7 @@ define_properties! {
   "line-height": LineHeight(LineHeight),
   "font": Font(Font<'i>) shorthand: true,
   "vertical-align": VerticalAlign(VerticalAlign),
-  "font-palette": FontPalette(DashedIdent<'i>),
+  "font-palette": FontPalette(DashedIdentReference<'i>),
 
   "transition-property": TransitionProperty(SmallVec<[PropertyId<'i>; 1]>, VendorPrefix) / WebKit / Moz / Ms,
   "transition-duration": TransitionDuration(SmallVec<[Time; 1]>, VendorPrefix) / WebKit / Moz / Ms,

--- a/src/properties/overflow.rs
+++ b/src/properties/overflow.rs
@@ -91,7 +91,7 @@ impl<'i> PropertyHandler<'i> for OverflowHandler {
     &mut self,
     property: &Property<'i>,
     dest: &mut DeclarationList<'i>,
-    context: &mut PropertyHandlerContext<'i>,
+    context: &mut PropertyHandlerContext<'i, '_>,
   ) -> bool {
     use Property::*;
 
@@ -117,7 +117,7 @@ impl<'i> PropertyHandler<'i> for OverflowHandler {
     true
   }
 
-  fn finalize(&mut self, dest: &mut DeclarationList, _: &mut PropertyHandlerContext<'i>) {
+  fn finalize(&mut self, dest: &mut DeclarationList, _: &mut PropertyHandlerContext<'i, '_>) {
     if self.x.is_none() && self.y.is_none() {
       return;
     }

--- a/src/properties/position.rs
+++ b/src/properties/position.rs
@@ -125,7 +125,7 @@ impl<'i> PropertyHandler<'i> for PositionHandler {
     &mut self,
     property: &Property<'i>,
     _: &mut DeclarationList<'i>,
-    _: &mut PropertyHandlerContext<'i>,
+    _: &mut PropertyHandlerContext<'i, '_>,
   ) -> bool {
     if let Property::Position(position) = property {
       if let (Some(Position::Sticky(cur)), Position::Sticky(new)) = (&mut self.position, position) {
@@ -140,7 +140,7 @@ impl<'i> PropertyHandler<'i> for PositionHandler {
     false
   }
 
-  fn finalize(&mut self, dest: &mut DeclarationList, _: &mut PropertyHandlerContext<'i>) {
+  fn finalize(&mut self, dest: &mut DeclarationList, _: &mut PropertyHandlerContext<'i, '_>) {
     if self.position.is_none() {
       return;
     }

--- a/src/properties/prefix_handler.rs
+++ b/src/properties/prefix_handler.rs
@@ -116,7 +116,7 @@ macro_rules! define_fallbacks {
     }
 
     impl<'i> PropertyHandler<'i> for FallbackHandler {
-      fn handle_property(&mut self, property: &Property<'i>, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i>) -> bool {
+      fn handle_property(&mut self, property: &Property<'i>, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i, '_>) -> bool {
         match property {
           $(
             Property::$name(val $(, mut $p)?) => {

--- a/src/properties/size.rs
+++ b/src/properties/size.rs
@@ -173,7 +173,7 @@ impl<'i> PropertyHandler<'i> for SizeHandler {
     &mut self,
     property: &Property<'i>,
     dest: &mut DeclarationList<'i>,
-    context: &mut PropertyHandlerContext<'i>,
+    context: &mut PropertyHandlerContext<'i, '_>,
   ) -> bool {
     let logical_supported = context.is_supported(Feature::LogicalSize);
 
@@ -239,5 +239,5 @@ impl<'i> PropertyHandler<'i> for SizeHandler {
     true
   }
 
-  fn finalize(&mut self, _: &mut DeclarationList, _: &mut PropertyHandlerContext<'i>) {}
+  fn finalize(&mut self, _: &mut DeclarationList, _: &mut PropertyHandlerContext<'i, '_>) {}
 }

--- a/src/properties/text.rs
+++ b/src/properties/text.rs
@@ -950,7 +950,7 @@ impl<'i> PropertyHandler<'i> for TextDecorationHandler<'i> {
     &mut self,
     property: &Property<'i>,
     dest: &mut DeclarationList<'i>,
-    context: &mut PropertyHandlerContext<'i>,
+    context: &mut PropertyHandlerContext<'i, '_>,
   ) -> bool {
     use Property::*;
 
@@ -1047,7 +1047,7 @@ impl<'i> PropertyHandler<'i> for TextDecorationHandler<'i> {
     true
   }
 
-  fn finalize(&mut self, dest: &mut DeclarationList<'i>, _: &mut PropertyHandlerContext<'i>) {
+  fn finalize(&mut self, dest: &mut DeclarationList<'i>, _: &mut PropertyHandlerContext<'i, '_>) {
     if !self.has_any {
       return;
     }

--- a/src/properties/transform.rs
+++ b/src/properties/transform.rs
@@ -1650,7 +1650,7 @@ impl<'i> PropertyHandler<'i> for TransformHandler {
     &mut self,
     property: &Property<'i>,
     dest: &mut DeclarationList<'i>,
-    _: &mut PropertyHandlerContext<'i>,
+    _: &mut PropertyHandlerContext<'i, '_>,
   ) -> bool {
     use Property::*;
 
@@ -1711,7 +1711,7 @@ impl<'i> PropertyHandler<'i> for TransformHandler {
     true
   }
 
-  fn finalize(&mut self, dest: &mut DeclarationList, _: &mut PropertyHandlerContext<'i>) {
+  fn finalize(&mut self, dest: &mut DeclarationList, _: &mut PropertyHandlerContext<'i, '_>) {
     self.flush(dest);
   }
 }

--- a/src/properties/transition.rs
+++ b/src/properties/transition.rs
@@ -131,7 +131,7 @@ impl<'i> PropertyHandler<'i> for TransitionHandler<'i> {
     &mut self,
     property: &Property<'i>,
     dest: &mut DeclarationList<'i>,
-    context: &mut PropertyHandlerContext<'i>,
+    context: &mut PropertyHandlerContext<'i, '_>,
   ) -> bool {
     use Property::*;
 
@@ -210,13 +210,13 @@ impl<'i> PropertyHandler<'i> for TransitionHandler<'i> {
     true
   }
 
-  fn finalize(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i>) {
+  fn finalize(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i, '_>) {
     self.flush(dest, context);
   }
 }
 
 impl<'i> TransitionHandler<'i> {
-  fn flush(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i>) {
+  fn flush(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i, '_>) {
     if !self.has_any {
       return;
     }

--- a/src/rules/font_face.rs
+++ b/src/rules/font_face.rs
@@ -469,7 +469,11 @@ impl<'i> cssparser::DeclarationParser<'i> for FontFaceDeclarationParser {
     }
 
     input.reset(&state);
-    return Ok(FontFaceProperty::Custom(CustomProperty::parse(name.into(), input)?));
+    return Ok(FontFaceProperty::Custom(CustomProperty::parse(
+      name.into(),
+      input,
+      &Default::default(),
+    )?));
   }
 }
 

--- a/src/rules/font_palette_values.rs
+++ b/src/rules/font_palette_values.rs
@@ -116,6 +116,7 @@ impl<'i> cssparser::DeclarationParser<'i> for FontPaletteValuesDeclarationParser
     return Ok(FontPaletteValuesProperty::Custom(CustomProperty::parse(
       name.into(),
       input,
+      &Default::default(),
     )?));
   }
 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -391,6 +391,10 @@ impl<'i> CssRuleList<'i> {
           }
         }
         CssRule::FontPaletteValues(f) => {
+          if context.unused_symbols.contains(f.name.0.as_ref()) {
+            continue;
+          }
+
           f.minify(context, parent_is_unused);
 
           if let Some(targets) = context.targets {

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -232,7 +232,7 @@ pub(crate) struct MinifyContext<'a, 'i> {
   pub targets: &'a Option<Browsers>,
   pub handler: &'a mut DeclarationHandler<'i>,
   pub important_handler: &'a mut DeclarationHandler<'i>,
-  pub handler_context: &'a mut PropertyHandlerContext<'i>,
+  pub handler_context: &'a mut PropertyHandlerContext<'i, 'a>,
   pub unused_symbols: &'a HashSet<String>,
   pub custom_media: Option<HashMap<CowArcStr<'i>, CustomMediaRule<'i>>>,
 }
@@ -397,6 +397,11 @@ impl<'i> CssRuleList<'i> {
             let fallbacks = f.get_fallbacks(*targets);
             rules.push(rule);
             rules.extend(fallbacks);
+            continue;
+          }
+        }
+        CssRule::Property(property) => {
+          if context.unused_symbols.contains(property.name.0.as_ref()) {
             continue;
           }
         }

--- a/src/rules/property.rs
+++ b/src/rules/property.rs
@@ -18,15 +18,15 @@ use cssparser::*;
 pub struct PropertyRule<'i> {
   /// The name of the custom property to declare.
   #[cfg_attr(feature = "serde", serde(borrow))]
-  name: DashedIdent<'i>,
+  pub name: DashedIdent<'i>,
   /// A syntax string to specify the grammar for the custom property.
-  syntax: SyntaxString,
+  pub syntax: SyntaxString,
   /// Whether the custom property is inherited.
-  inherits: bool,
+  pub inherits: bool,
   /// An optional initial value for the custom property.
-  initial_value: Option<ParsedComponent<'i>>,
+  pub initial_value: Option<ParsedComponent<'i>>,
   /// The location of the rule in the source file.
-  loc: Location,
+  pub loc: Location,
 }
 
 impl<'i> PropertyRule<'i> {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -63,9 +63,9 @@ pub(crate) trait PropertyHandler<'i>: Sized {
     &mut self,
     property: &Property<'i>,
     dest: &mut DeclarationList<'i>,
-    context: &mut PropertyHandlerContext<'i>,
+    context: &mut PropertyHandlerContext<'i, '_>,
   ) -> bool;
-  fn finalize(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i>);
+  fn finalize(&mut self, dest: &mut DeclarationList<'i>, context: &mut PropertyHandlerContext<'i, '_>);
 }
 
 pub(crate) mod private {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -5,7 +5,7 @@ use crate::declaration::{DeclarationBlock, DeclarationList};
 use crate::error::{ParserError, PrinterError};
 use crate::printer::Printer;
 use crate::properties::{Property, PropertyId};
-use crate::stylesheet::PrinterOptions;
+use crate::stylesheet::{ParserOptions, PrinterOptions};
 use crate::targets::Browsers;
 use crate::vendor_prefix::VendorPrefix;
 use cssparser::*;
@@ -24,6 +24,23 @@ pub trait Parse<'i>: Sized {
     let result = Self::parse(&mut parser)?;
     parser.expect_exhausted()?;
     Ok(result)
+  }
+}
+
+pub(crate) trait ParseWithOptions<'i>: Sized {
+  fn parse_with_options<'t>(
+    input: &mut Parser<'i, 't>,
+    options: &ParserOptions,
+  ) -> Result<Self, ParseError<'i, ParserError<'i>>>;
+}
+
+impl<'i, T: Parse<'i>> ParseWithOptions<'i> for T {
+  #[inline]
+  fn parse_with_options<'t>(
+    input: &mut Parser<'i, 't>,
+    _options: &ParserOptions,
+  ) -> Result<Self, ParseError<'i, ParserError<'i>>> {
+    T::parse(input)
   }
 }
 

--- a/src/values/ident.rs
+++ b/src/values/ident.rs
@@ -70,6 +70,6 @@ impl<'i> ToCss for DashedIdent<'i> {
   where
     W: std::fmt::Write,
   {
-    dest.write_ident(&self.0)
+    dest.write_dashed_ident(&self.0, None)
   }
 }

--- a/src/values/ident.rs
+++ b/src/values/ident.rs
@@ -2,7 +2,7 @@
 
 use crate::error::{ParserError, PrinterError};
 use crate::printer::Printer;
-use crate::properties::css_modules::ComposesFrom;
+use crate::properties::css_modules::Specifier;
 use crate::traits::{Parse, ParseWithOptions, ToCss};
 use crate::values::string::CowArcStr;
 use cssparser::*;
@@ -90,7 +90,7 @@ pub struct DashedIdentReference<'i> {
   pub ident: DashedIdent<'i>,
   /// CSS modules extension: the filename where the variable is defined.
   /// Only enabled when the CSS modules `dashed_idents` option is turned on.
-  pub from: Option<ComposesFrom<'i>>,
+  pub from: Option<Specifier<'i>>,
 }
 
 impl<'i> ParseWithOptions<'i> for DashedIdentReference<'i> {
@@ -103,7 +103,7 @@ impl<'i> ParseWithOptions<'i> for DashedIdentReference<'i> {
     let from = match &options.css_modules {
       Some(config) if config.dashed_idents => {
         if input.try_parse(|input| input.expect_ident_matching("from")).is_ok() {
-          Some(ComposesFrom::parse(input)?)
+          Some(Specifier::parse(input)?)
         } else {
           None
         }


### PR DESCRIPTION
This adds support for hashing CSS dashed idents (i.e. `--foo`), most commonly CSS variables, just like other custom idents in CSS modules (e.g. class names). This is opt-in because it was not originally handled by the CSS modules support in other tools.

Hashing dashed idents keeps these declarations local to the module just like other names in CSS modules. The names are included in the mapping passed to JS just like other names as well, meaning you can reference a CSS variable like this:

```js
import * as style from './style.module.css';

style['--foo']
```

This also means which variables are used can be tracked across files, and unused variable declarations can be automatically removed! Closes #58.

By default, all variable references are scoped to the module, so you can only reference variables declared in that file. A syntax extension has been added so that identifiers can be referenced between different CSS files. It is similar to the `composes` property.

```css
.foo {
  color: var(--color from "./colors.module.css");
}
```

You can also reference a global variable like this:

```css
.foo {
  color: var(--color from global);
}
```

This applies not only to CSS variables but anywhere the `<dashed-ident>` production is used in CSS. Right now that means `@font-palette-values` and `@property`, but others such as `@custom-media` and `@color-profile` are coming.

All of this is only enabled when the `dashedIdents` config option is turned on.

```json
{
  "cssModules": {
    "dashedIndents": true
  }
}
```