### PR TITLE
Remove Deprecated `retain_mut` Dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ bitflags = "1.3.2"
 parcel_sourcemap = "2.0.2"
 data-encoding = "2.3.2"
 lazy_static = "1.4.0"
-retain_mut = "0.1.5"
 const-str = "0.3.1"
 # CLI deps
 clap = { version = "3.0.6", features = ["derive"], optional = true }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.60.0"
+channel = "1.61.0"
 components = ["rustfmt", "clippy"]

--- a/src/media_query.rs
+++ b/src/media_query.rs
@@ -11,7 +11,6 @@ use crate::values::number::CSSNumber;
 use crate::values::string::CowArcStr;
 use crate::values::{length::Length, ratio::Ratio, resolution::Resolution};
 use cssparser::*;
-use retain_mut::RetainMut;
 use std::collections::{HashMap, HashSet};
 
 /// A [media query list](https://drafts.csswg.org/mediaqueries/#mq-list).
@@ -883,7 +882,7 @@ fn process_condition<'i>(
     }
     MediaCondition::Operation(conditions, _) => {
       let mut res = Ok(true);
-      RetainMut::retain_mut(conditions, |condition| {
+      conditions.retain_mut(|condition| {
         let r = process_condition(loc, custom_media, media_type, qualifier, condition, seen);
         if let Ok(used) = r {
           used


### PR DESCRIPTION
Hi there,

The [retain_mut](https://crates.io/crates/retain_mut) crate has been deprecated and archived now that the functionality has been officially stabilized. That dependency should be removed once you're comfortable bumping this project's MSRV to `1.61.0`.

This pull request does just that. :wink: