### PR TITLE
CLI: Return code and CSS modules as JSON when output file is not given

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ struct CliArgs {
   custom_media: bool,
   /// Enable CSS modules in output.
   /// If no filename is provided, <output_file>.json will be used.
-  #[clap(long, group = "css_modules", requires = "output_file")]
+  #[clap(long, group = "css_modules")]
   css_modules: Option<Option<String>>,
   /// Enable sourcemap, at <output_file>.map
   #[clap(long, requires = "output_file")]
@@ -142,7 +142,17 @@ pub fn main() -> Result<(), std::io::Error> {
       }
     }
   } else {
-    println!("{}", res.code);
+    if let Some(exports) = res.exports {
+      println!(
+        "{}",
+        serde_json::json!({
+          "code": res.code,
+          "modules": exports
+        })
+      );
+    } else {
+      println!("{}", res.code);
+    }
   }
 
   Ok(())


### PR DESCRIPTION
My very first rust experience, so be gentle ;)

I wanted a way to get both the resulting code and the CSS modules from the CLI without having to specify an output file, which means I would have to read files to get what I want.

So in this PR, if `output-file` flag is not given, and `css-modules` flag is given, the CLI will return a JSON string containing the code and the CSS modules...

```json
{
  "code": ".cLD2Uq_header {\n  background-color: #00f;\n}\n",
  "modules": {
    "header": { "composes": [], "isReferenced": false, "name": "cLD2Uq_header" }
  }
}
```

All other functionality is maintained.

Would appreciate any feedback. thx