### PR TITLE
Custom JS resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,6 +720,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thread_local",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,40 +239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "lazy_static",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +378,95 @@ name = "fs_extra"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
+name = "futures"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+
+[[package]]
+name = "futures-task"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+
+[[package]]
+name = "futures-util"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "fxhash"
@@ -760,6 +837,8 @@ version = "1.0.0-alpha.27"
 dependencies = [
  "assert_cmd",
  "assert_fs",
+ "async-recursion",
+ "async-trait",
  "bitflags",
  "browserslist-rs",
  "clap",
@@ -767,6 +846,7 @@ dependencies = [
  "cssparser",
  "dashmap",
  "data-encoding",
+ "futures",
  "indoc",
  "itertools",
  "jemallocator",
@@ -775,10 +855,10 @@ dependencies = [
  "parcel_sourcemap",
  "pathdiff",
  "predicates",
- "rayon",
  "serde",
  "serde_json",
  "smallvec",
+ "tokio",
 ]
 
 [[package]]
@@ -797,6 +877,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_bytes",
  "serde_json",
+ "tokio",
  "wasm-bindgen",
 ]
 
@@ -943,6 +1024,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,11 +1109,11 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1101,31 +1194,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core",
-]
-
-[[package]]
-name = "rayon"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
-dependencies = [
- "autocfg",
- "crossbeam-deque",
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
- "lazy_static",
- "num_cpus",
 ]
 
 [[package]]
@@ -1293,6 +1361,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a86232ab60fa71287d7f2ddae4a7073f6b7aac33631c3015abb556f08c6d0a3e"
 
 [[package]]
+name = "slab"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+
+[[package]]
 name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,13 +1409,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1419,10 +1493,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "tokio"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "95eec79ea28c00a365f539f1961e9278fbcaf81c0ff6aaf0e93c181352446948"
+dependencies = [
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
 name = "unindent"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "callback-future"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b76a63a41df0ba9490dd817a3d98511c6d3d9e530eff9bcf5f3de2a6723d1c3f"
+dependencies = [
+ "futures",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,7 +875,10 @@ dependencies = [
 name = "parcel_css_node"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "callback-future",
  "cssparser",
+ "futures",
  "jemallocator",
  "js-sys",
  "napi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ path = "src/lib.rs"
 crate-type = ["rlib"]
 
 [dependencies]
+async-recursion = "1.0.0"
+async-trait = "0.1.53"
+futures = "0.3.21"
 serde = { version = "1.0.123", features = ["derive"] }
 cssparser = "0.29.1"
 parcel_selectors = { version = "0.24.4", path = "./selectors" }
@@ -35,12 +38,12 @@ parcel_sourcemap = "2.0.2"
 data-encoding = "2.3.2"
 lazy_static = "1.4.0"
 const-str = "0.3.1"
+tokio = { version = "1.19.1", features = ["macros", "rt", "rt-multi-thread"] }
 # CLI deps
 clap = { version = "3.0.6", features = ["derive"], optional = true }
 serde_json = { version = "1.0.78", optional = true }
 pathdiff = { version = "0.2.1", optional = true }
 browserslist-rs = { version = "0.7.0", optional = true }
-rayon = "1.5.1"
 dashmap = "5.0.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -20,7 +20,7 @@ parcel_sourcemap = "2.0.2"
 jemallocator = { version = "0.3.2", features = ["disable_initial_exec_tls"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-napi = {version = "2.2.0", default-features = false, features = ["napi4", "compat-mode", "serde-json"]}
+napi = {version = "2.2.0", default-features = false, features = ["napi4", "compat-mode", "serde-json", "tokio_rt"]}
 napi-derive = "2"
 tokio = {version = "1.19.0", features = ["rt", "rt-multi-thread"]}
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -22,6 +22,7 @@ jemallocator = { version = "0.3.2", features = ["disable_initial_exec_tls"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 napi = {version = "2.2.0", default-features = false, features = ["napi4", "compat-mode", "serde-json"]}
 napi-derive = "2"
+tokio = {version = "1.19.0", features = ["rt", "rt-multi-thread"]}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -20,7 +20,10 @@ parcel_sourcemap = "2.0.2"
 jemallocator = { version = "0.3.2", features = ["disable_initial_exec_tls"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-napi = {version = "2.2.0", default-features = false, features = ["napi4", "compat-mode", "serde-json", "tokio_rt"]}
+async-trait = "0.1.53"
+callback-future = "0.1"
+futures = "0.3.21"
+napi = {version = "2.2.0", default-features = false, features = ["napi5", "compat-mode", "serde-json", "tokio_rt"]}
 napi-derive = "2"
 tokio = {version = "1.19.0", features = ["rt", "rt-multi-thread"]}
 

--- a/node/index.d.ts
+++ b/node/index.d.ts
@@ -197,3 +197,25 @@ export declare function browserslistToTargets(browserslist: string[]): Targets;
  * Bundles a CSS file and its dependencies, inlining @import rules.
  */
 export declare function bundle(options: BundleOptions): TransformResult;
+
+export interface AsyncBundleOptions extends BundleOptions {
+  resolver?: Resolver;
+}
+
+/** Custom resolver to use when loading CSS files. */
+export interface Resolver {
+  /** Read the given file and return its contents as a string. */
+  read?: (file: string) => string | Promise<string>;
+
+  /**
+   * Resolve the given CSS import specifier from the provided originating file to a
+   * path which gets passed to `read()`.
+   */
+  resolve?: (specifier: string, originatingFile: string) => string | Promise<string>;
+}
+
+/**
+ * Bundles a CSS file and its dependencies asynchronously, inlining @import rules.
+ * Also supports custom resolvers.
+ */
+export declare function bundleAsync(options: AsyncBundleOptions): Promise<TransformResult>;

--- a/node/index.js
+++ b/node/index.js
@@ -23,3 +23,48 @@ if (process.env.CSS_TRANSFORMER_WASM) {
 }
 
 module.exports.browserslistToTargets = require('./browserslistToTargets');
+
+// Include a small JS-shim for `bundleAsync()` to convert make `resolver` more ergonomic.
+const {bundleAsync} = module.exports;
+module.exports.bundleAsync = (opts, ...rest) => {
+  return bundleAsync({
+    ...opts,
+    resolver: opts.resolver && {
+      ...opts.resolver,
+      read: opts.resolver.read && normalizeJsCallback(opts.resolver.read.bind(opts.resolver)),
+      resolve: opts.resolver.resolve && normalizeJsCallback(opts.resolver.resolve.bind(opts.resolver)),
+    },
+  }, ...rest);
+};
+
+// `napi-rs` ignores JS function return values, so any results must be passed back to
+// the Rust side via a callback rather than a returned value or `Promise`. This
+// callback also follows NodeJS conventions (`callback(err, result)`). Managing the
+// error and callback are annoying for users, so this converts a typical JS function
+// which returns its result in a `Promise` into a N-API-compatible function which
+// accepts and propagates its results to a callback.
+function normalizeJsCallback(func) {
+  return (...args) => {
+    // Splice out `[...args, callback]`.
+    const funcArgs = args.slice(0, -1);
+    const callback = args[args.length - 1];
+
+    // Invoke the inner function, normalize to a `Promise`, and then invoke the callback
+    // function with Node conventions of `callback(err, result)`.
+    toPromise(() => func(...funcArgs)).then(
+      (result) => callback(null, result),
+      (err) => callback(err, null),
+    );
+  };
+}
+
+// Converts the given function execution to return a `Promise` instead of returning or
+// erroring synchronously. This is different from `Promise.resolve(func())` in that a
+// synchronous `throw` statement is converted to a `Promise` rejection.
+function toPromise(func) {
+  try {
+    return Promise.resolve(func());
+  } catch (err) {
+    return Promise.reject(err);
+  }
+}

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -2,6 +2,7 @@
 #[global_allocator]
 static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
+use async_trait::async_trait;
 use parcel_css::bundler::{BundleErrorKind, Bundler, FileProvider, SourceProvider};
 use parcel_css::css_modules::{CssModuleExports, CssModuleReferences, PatternParseError};
 use parcel_css::dependencies::Dependency;
@@ -12,9 +13,14 @@ use parcel_css::stylesheet::{
 use parcel_css::targets::Browsers;
 use parcel_sourcemap::SourceMap;
 use serde::{Deserialize, Serialize};
+use std::cell::Cell;
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::Mutex;
 use tokio::runtime::Runtime;
+
+use callback_future::CallbackFuture;
 
 // ---------------------------------------------
 
@@ -46,7 +52,11 @@ pub fn transform_style_attribute(config_val: JsValue) -> Result<JsValue, JsValue
 // ---------------------------------------------
 
 #[cfg(not(target_arch = "wasm32"))]
-use napi::{CallContext, JsObject, JsUnknown};
+use napi::threadsafe_function::{
+  ErrorStrategy, ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode,
+};
+#[cfg(not(target_arch = "wasm32"))]
+use napi::{CallContext, JsFunction, JsObject, JsUnknown};
 #[cfg(not(target_arch = "wasm32"))]
 use napi_derive::{js_function, module_exports};
 
@@ -167,12 +177,95 @@ fn bundle_async(ctx: CallContext) -> napi::Result<JsObject> {
   let opts = ctx.get::<JsObject>(0)?;
   let config: BundleConfig = ctx.env.from_js_value(&opts)?;
 
+  // Get `read()` and `resolve()` JS functions.
+  let maybe_resolver = &opts.get::<&str, JsObject>("resolver")?;
+  let maybe_unsafe_read = match &maybe_resolver {
+    None => None,
+    Some(resolver) => match resolver.get::<&str, JsUnknown>("read")? {
+      None => None,
+      Some(read) => {
+        let read_type = read.get_type().unwrap();
+        if read_type != napi::ValueType::Function {
+          return Err(napi::Error::new(
+            napi::Status::FunctionExpected,
+            format!(
+              "Expected `resolver.read` to be of type `{}` but was of type `{}`",
+              napi::ValueType::Function,
+              read_type
+            ),
+          ));
+        }
+
+        Some(unsafe { read.cast::<JsFunction>() })
+      }
+    },
+  };
+  let maybe_unsafe_resolve = match &maybe_resolver {
+    None => None,
+    Some(resolver) => match resolver.get::<&str, JsUnknown>("resolve")? {
+      None => None,
+      Some(resolve) => {
+        let resolve_type = resolve.get_type().unwrap();
+        if resolve_type != napi::ValueType::Function {
+          return Err(napi::Error::new(
+            napi::Status::FunctionExpected,
+            format!(
+              "Expected `resolver.resolve` to be of type `{}` but was of type `{}`.",
+              napi::ValueType::Function,
+              resolve_type
+            ),
+          ));
+        }
+
+        Some(unsafe { resolve.cast::<JsFunction>() })
+      }
+    },
+  };
+
+  // Map `read()` and `resolve()` to thread-safe N-API functions.
+  let maybe_read: Option<ThreadsafeFunction<ReadArgs, ErrorStrategy::Fatal>> = match maybe_unsafe_read {
+    None => None,
+    Some(unsafe_read) => Some(unsafe_read.create_threadsafe_function(
+      0, /* max_queue_size */
+      // On the main thread, convert Rust args struct into JS arguments.
+      |ctx: ThreadSafeCallContext<ReadArgs>| {
+        Ok(vec![
+          ctx.env.create_string(&ctx.value.file.to_str().unwrap())?.into_unknown(),
+          ctx
+            .env
+            .create_function_from_closure("callback", ctx.value.callback)?
+            .into_unknown(),
+        ])
+      },
+    )?),
+  };
+  let maybe_resolve = match maybe_unsafe_resolve {
+    None => None,
+    Some(unsafe_resolve) => Some(unsafe_resolve.create_threadsafe_function(
+      0, /* max_queue_size */
+      // On the main thread, convert Rust args struct into JS arguments.
+      |ctx: ThreadSafeCallContext<ResolveArgs>| {
+        Ok(vec![
+          ctx.env.create_string(&ctx.value.specifier)?.into_unknown(),
+          ctx
+            .env
+            .create_string(ctx.value.originating_file.to_str().unwrap())?
+            .into_unknown(),
+          ctx
+            .env
+            .create_function_from_closure("callback", ctx.value.callback)?
+            .into_unknown(),
+        ])
+      },
+    )?),
+  };
+
   // Execute asynchronous operation and return a `Promise` to JS.
   ctx.env.execute_tokio_future(
     // Perform asynchronous work, *cannot* access JS data from here.
     async {
-      let fs = FileProvider::new();
-      let res = compile_bundle(&fs, &config).await;
+      let source_provider = JsSourceProvider::new(FileProvider::new(), maybe_read, maybe_resolve);
+      let res = compile_bundle(&source_provider, &config).await;
       drop(config);
 
       match res {
@@ -184,8 +277,221 @@ fn bundle_async(ctx: CallContext) -> napi::Result<JsObject> {
       }
     },
     // Convert the result from Rust data to JS data.
-    |&mut env, transform_result| env.to_js_value(&transform_result)
+    |&mut env, transform_result| env.to_js_value(&transform_result),
   )
+}
+
+/// Arguments passed to the JS custom read function.
+struct ReadArgs {
+  file: PathBuf,
+  callback: Box<dyn Fn(CallContext) -> napi::Result<napi::JsUndefined> + Send>,
+}
+
+/// Arguments passed to the JS custom resolve function.
+struct ResolveArgs {
+  specifier: String,
+  originating_file: PathBuf,
+  callback: Box<dyn Fn(CallContext) -> napi::Result<napi::JsUndefined> + Send>,
+}
+
+/// Buffer containing cached source inputs. This wrapper struct is only necessary to be
+/// marked `Send` so it can be used with a `static` lifetime as required by
+/// `ThreadsafeFunction`. Since `JsSourceProvider` uses this in an `Arc<Mutex<Buffer>>`
+/// This can outlive the `JsSourceProvider` if necessary.
+struct InputCache {
+  inputs: Vec<*mut String>,
+}
+
+unsafe impl Send for InputCache {}
+
+impl Drop for InputCache {
+  fn drop(&mut self) {
+    for ptr in self.inputs.iter() {
+      std::mem::drop(unsafe { Box::from_raw(*ptr) });
+    }
+  }
+}
+
+/// A `SourceProvider` implementation which uses JS implementations where given, falling
+/// back to a wrapped `SourceProvider` where not given.
+struct JsSourceProvider<P>
+where
+  P: SourceProvider,
+{
+  /// Buffer with cached source files.
+  cache: Arc<Mutex<InputCache>>,
+
+  /// Fallback provider to use when no custom JS implementation is available for an
+  /// operation.
+  fallback_provider: P,
+
+  /// Custom JS `read()` function.
+  maybe_read: Option<ThreadsafeFunction<ReadArgs, ErrorStrategy::Fatal>>,
+
+  /// Custom JS `resolve()` function.
+  maybe_resolve: Option<ThreadsafeFunction<ResolveArgs, ErrorStrategy::Fatal>>,
+}
+
+impl<P: SourceProvider> JsSourceProvider<P> {
+  /// Creates a new `JsSourceProvider`.
+  fn new(
+    fallback_provider: P,
+    maybe_read: Option<ThreadsafeFunction<ReadArgs, ErrorStrategy::Fatal>>,
+    maybe_resolve: Option<ThreadsafeFunction<ResolveArgs, ErrorStrategy::Fatal>>,
+  ) -> JsSourceProvider<P> {
+    JsSourceProvider {
+      cache: Arc::new(Mutex::new(InputCache { inputs: Vec::new() })),
+      fallback_provider,
+      maybe_read,
+      maybe_resolve,
+    }
+  }
+}
+
+// JS implementations use thread-safe functions, so `JsSourceProvider` is thread-safe as
+// long as the fallback provider is also thread-safe.
+unsafe impl<P: SourceProvider + Send> Send for JsSourceProvider<P> {}
+unsafe impl<P: SourceProvider + Sync> Sync for JsSourceProvider<P> {}
+
+#[async_trait]
+impl<P: SourceProvider> SourceProvider for JsSourceProvider<P> {
+  async fn read<'a>(&'a self, file: &Path) -> std::io::Result<&'a str> {
+    let cache = self.cache.clone();
+    match self.maybe_read.clone() {
+      // Use fallback provider if no JS `read()` implementation exists.
+      None => self.fallback_provider.read(file).await,
+      // Use JS `read()` implementation.
+      Some(read) => {
+        let file = file.to_owned();
+
+        // Wait until JS calls back with the result.
+        CallbackFuture::<std::io::Result<&str>>::new(move |complete| {
+          // `complete` can only be called once, but JS could invoke this callback
+          // multiple times. Use a `Cell` to hide the mutability and restrict it to
+          // only be called once.
+          let complete = Cell::new(Some(complete));
+
+          // Invoke the JS `read()` function.
+          read.call(ReadArgs {
+            file,
+            // JS invokes this callback with the result. It follows Node async
+            // conventions (`cb(error, result)`).
+            callback: Box::new(move |ctx| {
+              // Get completion callback. This function can only be called once by JS
+              // so any subsequent executions should error immediately.
+              let complete = complete.take().ok_or(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "Callback invoked twice.",
+              ))?;
+
+              // Validate no errors were thrown.
+              let error = ctx.get::<JsUnknown>(0)?;
+              let error_type = error.get_type()?;
+              if error_type != napi::ValueType::Null && error_type != napi::ValueType::Undefined {
+                complete(Err(std::io::Error::new(std::io::ErrorKind::Other, format!(
+                  "`read()` threw error:\n{}",
+                  error.coerce_to_string()?.into_utf8()?.as_str()?.to_owned(),
+                ))));
+                return ctx.env.get_undefined();
+              }
+
+              // Validate that result was a string.
+              let result = ctx.get::<JsUnknown>(1)?;
+              let result_type = result.get_type()?;
+              if result_type != napi::ValueType::String {
+                complete(Err(std::io::Error::new(std::io::ErrorKind::Other, format!(
+                  "Expected `read()` to return a value of type `{}`, but it returned a value of type `{}` instead.", napi::ValueType::String, result_type,
+                ))));
+                return ctx.env.get_undefined();
+              }
+
+              // Get file contents and add to the source file cache.
+              let result = result.coerce_to_string()?.into_utf8()?.as_str()?.to_owned();
+              let ptr = Box::into_raw(Box::new(result));
+              cache.lock().unwrap().inputs.push(ptr);
+
+              // SAFETY: this is safe because the pointer is not dropped until the
+              // `JsSourceProvider` is, and we never remove from the list of pointers
+              // stored in the vector.
+              complete(Ok(unsafe { &*ptr }));
+
+              ctx.env.get_undefined()
+            }),
+          }, ThreadsafeFunctionCallMode::Blocking);
+        }).await
+      }
+    }
+  }
+
+  async fn resolve(&self, specifier: &str, originating_file: &Path) -> Result<PathBuf, Error<BundleErrorKind>> {
+    match self.maybe_resolve.clone() {
+      // Use fallback provider if no JS `resolve()` implementation exists.
+      None => self.fallback_provider.resolve(specifier, originating_file).await,
+      // Use JS `resolve()` implementation.
+      Some(resolve) => {
+        let specifier = specifier.to_owned();
+        let originating_file = originating_file.to_path_buf().to_owned();
+
+        // Wait until JS calls back with the result.
+        CallbackFuture::<Result<PathBuf, Error<BundleErrorKind>>>::new(move |complete| {
+          // `complete` can only be called once, but JS could invoke this callback
+          // multiple times. Use a `Cell` to hide the mutability and restrict it to
+          // only be called once.
+          let complete = Cell::new(Some(complete));
+
+          // Invoke the JS `resolve()` function.
+          resolve.call(ResolveArgs {
+            specifier,
+            originating_file,
+            // JS invokes this callback with the result.
+            callback: Box::new(move |ctx| {
+              // Get completion callback. This function can only be called once by JS
+              // so any subsequent executions should error immediately.
+              let complete = complete.take().ok_or(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "Callback invoked twice.",
+              ))?;
+
+              // Check for error.
+              let error = ctx.get::<JsUnknown>(0)?;
+              let error_type = error.get_type()?;
+              if error_type != napi::ValueType::Null && error_type != napi::ValueType::Undefined {
+                complete(Err(Error {
+                  kind: BundleErrorKind::IOError(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("`resolve()` threw error:\n{}", error.coerce_to_string()?.into_utf8()?.as_str()?.to_owned()),
+                  )),
+                  loc: None,
+                }));
+                return ctx.env.get_undefined();
+              }
+
+              // Validate that result was a string.
+              let result = ctx.get::<JsUnknown>(1)?;
+              let result_type = result.get_type()?;
+              if result_type != napi::ValueType::String {
+                complete(Err(Error {
+                  kind: BundleErrorKind::IOError(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("Expected `resolve()` to return a value of type `{}`, but it returned a value of type `{}` instead.", napi::ValueType::String, result_type),
+                  )),
+                  loc: None,
+                }));
+                return ctx.env.get_undefined();
+              }
+
+              // Convert JS string into a Rust `PathBuf`.
+              let resolved = result.coerce_to_string()?.into_utf8()?.as_str()?.to_owned();
+              let resolved = Path::new(&resolved).to_path_buf();
+              complete(Ok(resolved));
+
+              ctx.env.get_undefined()
+            }),
+          }, ThreadsafeFunctionCallMode::Blocking);
+        }).await
+      }
+    }
+  }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -344,8 +650,8 @@ fn compile<'i>(code: &'i str, config: &Config) -> Result<TransformResult, Compil
   })
 }
 
-async fn compile_bundle<'i>(
-  fs: &'i FileProvider,
+async fn compile_bundle<'i, P: SourceProvider>(
+  fs: &'i P,
   config: &BundleConfig,
 ) -> Result<TransformResult, CompileError<'i>> {
   let mut source_map = if config.source_map.unwrap_or(false) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,8 @@ struct SourceMapJson<'a> {
   names: &'a Vec<String>,
 }
 
-pub fn main() -> Result<(), std::io::Error> {
+#[tokio::main]
+pub async fn main() -> Result<(), std::io::Error> {
   let cli_args = CliArgs::parse();
   let source = fs::read_to_string(&cli_args.input_file)?;
 
@@ -101,7 +102,7 @@ pub fn main() -> Result<(), std::io::Error> {
 
   let mut stylesheet = if cli_args.bundle {
     let mut bundler = Bundler::new(&fs, source_map.as_mut(), options);
-    bundler.bundle(Path::new(&cli_args.input_file)).unwrap()
+    bundler.bundle(Path::new(&cli_args.input_file)).await.unwrap()
   } else {
     if let Some(sm) = &mut source_map {
       sm.add_source(&filename);

--- a/src/properties/font.rs
+++ b/src/properties/font.rs
@@ -932,7 +932,6 @@ const DEFAULT_SYSTEM_FONTS: &[&str] = &[
 /// This list is an attempt at providing that support
 #[inline]
 fn compatible_font_family(mut family: Option<Vec<FontFamily>>, is_supported: bool) -> Option<Vec<FontFamily>> {
-
   if is_supported {
     return family;
   }

--- a/test-bundle.mjs
+++ b/test-bundle.mjs
@@ -1,6 +1,23 @@
 import path from 'path';
 import css from './node/index.js';
 
+(function testBundleRejectsResolver() {
+    let error = undefined;
+    try {
+        css.bundle({
+            filename: 'foo.css',
+            resolver: {},
+        });
+    } catch (err) {
+        error = err;
+    }
+
+    if (!error) throw new Error(`\`testBundleRejectsResolver()\` failed. Expected \`bundle()\` to throw, but it did not.`);
+    if (!error.message.includes(`\`bundle()\` doesn't support custom JS resolvers`) || !error.message.includes(`Use \`bundleAsync()\` instead.`)) {
+        throw new Error(`\`testBundleRejectsResolver()\` failed. Expected \`bundle()\` to throw a specific error message, but it threw a different error:\n${error.message}`);
+    }
+}());
+
 (async function testResolver() {
     const inMemoryFs = new Map(Object.entries({
         'foo.css': `

--- a/test-bundle.mjs
+++ b/test-bundle.mjs
@@ -1,0 +1,262 @@
+import path from 'path';
+import css from './node/index.js';
+
+(async function testResolver() {
+    const inMemoryFs = new Map(Object.entries({
+        'foo.css': `
+@import 'root:bar.css';
+
+.foo { color: red; }
+        `.trim(),
+
+        'bar.css': `
+@import 'root:hello/world.css';
+
+.bar { color: green; }
+        `.trim(),
+
+        'hello/world.css': `
+.baz { color: blue; }
+        `.trim(),
+    }));
+
+    const { code: buffer } = await css.bundleAsync({
+        filename: 'foo.css',
+        resolver: {
+            read(file) {
+                const result = inMemoryFs.get(path.normalize(file));
+                if (!result) throw new Error(`Could not find ${file} in ${
+                    Array.from(inMemoryFs.keys()).join(', ')}.`);
+                return result;
+            },
+
+            resolve(specifier) {
+                return specifier.slice('root:'.length);
+            },
+        },
+    });
+    const code = buffer.toString('utf-8').trim();
+
+    const expected = `
+.baz {
+  color: #00f;
+}
+
+.bar {
+  color: green;
+}
+
+.foo {
+  color: red;
+}
+    `.trim();
+    if (code !== expected) throw new Error(`\`testResolver()\` failed. Expected:\n${expected}\n\nGot:\n${code}`);
+})();
+
+(async function testOnlyCustomRead() {
+    const inMemoryFs = new Map(Object.entries({
+        'foo.css': `
+@import 'hello/world.css';
+
+.foo { color: red; }
+        `.trim(),
+
+        'hello/world.css': `
+@import '../bar.css';
+
+.bar { color: green; }
+        `.trim(),
+
+        'bar.css': `
+.baz { color: blue; }
+        `.trim(),
+    }));
+
+    const { code: buffer } = await css.bundleAsync({
+        filename: 'foo.css',
+        resolver: {
+            read(file) {
+                const result = inMemoryFs.get(path.normalize(file));
+                if (!result) throw new Error(`Could not find ${file} in ${
+                    Array.from(inMemoryFs.keys()).join(', ')}.`);
+                return result;
+            },
+        },
+    });
+    const code = buffer.toString('utf-8').trim();
+
+    const expected = `
+.baz {
+  color: #00f;
+}
+
+.bar {
+  color: green;
+}
+
+.foo {
+  color: red;
+}
+    `.trim();
+    if (code !== expected) throw new Error(`\`testOnlyCustomRead()\` failed. Expected:\n${expected}\n\nGot:\n${code}`);
+})();
+
+(async function testOnlyCustomResolve() {
+    const root = path.join('tests', 'testdata', 'css');
+    const { code: buffer } = await css.bundleAsync({
+        filename: path.join(root, 'foo.css'),
+        resolver: {
+            resolve(specifier) {
+                // Strip `root:` prefix off specifier and resolve it as an absolute path
+                // in the test data root.
+                return path.join(root, specifier.slice('root:'.length));
+            },
+        },
+    });
+    const code = buffer.toString('utf-8').trim();
+
+    const expected = `
+.baz {
+  color: #00f;
+}
+
+.bar {
+  color: green;
+}
+
+.foo {
+  color: red;
+}
+    `.trim();
+    if (code !== expected) throw new Error(`\`testOnlyCustomResolve()\` failed. Expected:\n${expected}\n\nGot:\n${code}`);
+})();
+
+(async function testReadThrow() {
+    let error = undefined;
+    try {
+        await css.bundleAsync({
+            filename: 'foo.css',
+            resolver: {
+                read(file) {
+                    throw new Error(`Oh noes! Failed to read \`${file}\`.`);
+                }
+            },
+        });
+    } catch (err) {
+        error = err;
+    }
+
+    if (!error) throw new Error(`\`testReadThrow()\` failed. Expected \`bundleAsync()\` to throw, but it did not.`);
+    if (!error.message.includes(`\`read()\` threw error:`) || !error.message.includes(`Oh noes! Failed to read \`foo.css\`.`)) {
+        throw new Error(`\`testReadThrow()\` failed. Expected \`bundleAsync()\` to throw a specific error message, but it threw a different error:\n${error.message}`);
+    }
+})();
+
+(async function testResolveThrow() {
+    let error = undefined;
+    try {
+        await css.bundleAsync({
+            filename: 'tests/testdata/css/foo.css',
+            resolver: {
+                resolve(specifier, originatingFile) {
+                    throw new Error(`Oh noes! Failed to resolve \`${specifier}\` from \`${
+                        originatingFile}\`.`);
+                }
+            },
+        });
+    } catch (err) {
+        error = err;
+    }
+
+    if (!error) throw new Error(`\`testResolveThrow()\` failed. Expected \`bundleAsync()\` to throw, but it did not.`);
+    if (!error.message.includes(`\`resolve()\` threw error:`) || !error.message.includes(`Oh noes! Failed to resolve \`root:hello/world.css\` from \`tests/testdata/css/foo.css\`.`)) {
+        throw new Error(`\`testResolveThrow()\` failed. Expected \`bundleAsync()\` to throw a specific error message, but it threw a different error:\n${error.message}`);
+    }
+})();
+
+(async function testReadReturnNonString() {
+    let error = undefined;
+    try {
+        await css.bundleAsync({
+            filename: 'foo.css',
+            resolver: {
+                read() {
+                    return 1234; // Returns a non-string value.
+                }
+            },
+        });
+    } catch (err) {
+        error = err;
+    }
+
+    if (!error) throw new Error(`\`testReadReturnNonString()\` failed. Expected \`bundleAsync()\` to throw, but it did not.`);
+    if (!error.message.includes(`Expected \`read()\` to return a value of type \`String\`, but it returned a value of type \`Number\` instead.`)) {
+        throw new Error(`\`testReadReturnNonString()\` failed. Expected \`bundleAsync()\` to throw a specific error message, but it threw a different error:\n${error.message}`);
+    }
+})();
+
+(async function testResolveReturnNonString() {
+    let error = undefined;
+    try {
+        await css.bundleAsync({
+            filename: 'tests/testdata/css/foo.css',
+            resolver: {
+                resolve() {
+                    return 1234; // Returns a non-string value.
+                }
+            },
+        });
+    } catch (err) {
+        error = err;
+    }
+
+    if (!error) throw new Error(`\`testResolveReturnNonString()\` failed. Expected \`bundleAsync()\` to throw, but it did not.`);
+    if (!error.message.includes(`Expected \`resolve()\` to return a value of type \`String\`, but it returned a value of type \`Number\` instead.`)) {
+        throw new Error(`\`testResolveReturnNonString()\` failed. Expected \`bundleAsync()\` to throw a specific error message, but it threw a different error:\n${error.message}`);
+    }
+})();
+
+(async function testThis() {
+    const inMemoryFs = new Map(Object.entries({
+        'foo.css': `
+@import './bar.css';
+
+.foo { color: red; }
+        `.trim(),
+
+        'bar.css': `
+@import './hello/world.css';
+
+.bar { color: green; }
+        `.trim(),
+
+        'hello/world.css': `
+.baz { color: blue; }
+        `.trim(),
+    }));
+
+    let readThis = undefined;
+    let resolveThis = undefined;
+    const resolver = {
+        read: function (file) {
+            readThis = this;
+            const result = inMemoryFs.get(path.normalize(file));
+            if (!result) throw new Error(`Could not find ${file} in ${
+                Array.from(inMemoryFs.keys()).join(', ')}.`);
+            return result;
+        },
+        resolve: function (specifier, originatingFile) {
+            resolveThis = this;
+            return path.join(originatingFile, '..', specifier);
+        },
+    };
+    await css.bundleAsync({
+        filename: 'foo.css',
+        resolver,
+    });
+
+    if (readThis !== resolver) throw new Error(`\`testThis()\` failed. Expected \`read()\` to be called with the \`resolver\` as \`this\`, but instead it was called with:\n${readThis}`);
+    if (resolveThis !== resolver) throw new Error(`\`testThis()\` failed. Expected \`resolve()\` to be called with the \`resolver\` as \`this\`, but instead it was called with:\n${resolveThis}`);
+})();
+
+console.log('PASSED!');

--- a/tests/testdata/css/baz.css
+++ b/tests/testdata/css/baz.css
@@ -1,0 +1,1 @@
+.baz { color: blue; }

--- a/tests/testdata/css/foo.css
+++ b/tests/testdata/css/foo.css
@@ -1,0 +1,3 @@
+@import 'root:hello/world.css';
+
+.foo { color: red; }

--- a/tests/testdata/css/hello/world.css
+++ b/tests/testdata/css/hello/world.css
@@ -1,0 +1,3 @@
+@import 'root:baz.css';
+
+.bar { color: green; }


### PR DESCRIPTION
This adds a new `bundleAsync()` function with support for a custom JavaScript resolver. A resolver which re-implements the default Rust behavior looks like:

```typescript
import { promises as fs } from 'fs';
import * as path from 'path';
import css from '@parcel/css';

await css.bundleAsync({
  filename: 'foo.css',
  // Custom resolver.
  resolver: {
    // Custom read function, takes a file path and returns its contents.
    async read(file: string): Promise<string> {
      return await fs.readFile(file, 'utf-8');
    },

    // Custom resolve function, takes an import specifier and the file it
    // originated from, and returns its full path which will be passed to `read()`.
    async resolve(specifier: string, originatingFile: string): Promise<string> {
      return path.join(originatingFile, '..', specifier);
    }
  },
});
```

This required some changes to the way work is parallelized to be compatible with `async/await`. I had to remove Rayon as it doesn't seem compatible with this model. This resulted in two still-unsolved issues (edit: these should both be resolved now, see https://github.com/parcel-bundler/parcel-css/pull/196#issuecomment-1166173469):
1.  Tests build, but at least one fails with a layering issue:
    ```
    ---- bundler::tests::test_bundle stdout ----
    thread 'bundler::tests::test_bundle' panicked at 'assertion failed: `(left == right)`
      left: `"@layer bar, foo;\n@layer qux, baz;\n\n@layer foo.baz {\n  div {\n    background: #ff0;\n  }\n}\n\n@layer foo {\n@layer qux {\n    div {\n      background: green;\n    }\n  }\n}\n\n@layer bar {\n  div {\n    background: red;\n  }\n}\n"`,
     right: `"@layer bar, foo;\n@layer foo.qux, foo.baz;\n\n@layer foo.baz {\n  div {\n    background: #ff0;\n  }\n}\n\n@layer foo {\n  @layer qux {\n    div {\n      background: green;\n    }\n  }\n}\n\n@layer bar {\n  div {\n    background: red;\n  }\n}\n"`', src/bundler.rs:1176:5
    ```
    I think the reason for this is because of subtle changes to `loadFile()` where I had to clone each rule during processing to resolve ownership issues. I'll leave a comment at the relevant place in the PR.
1. I'm pretty sure removing Rayon means that everything is left on the main thread. It runs _concurrently_ given that everything is `async` and joined with `futures::future::join_all()`, but as soon as one operation gets blocked all of them are blocked. Since we can't use Rayon for this, I suspect [`tokio::spawn()`](https://docs.rs/tokio/latest/tokio/fn.spawn.html) could serve the purpose of abstracting out all the details of how many threads to create and how to distribute jobs for them, but it ran into similar ownership issues from 1. and I couldn't find a good way to get it working.

Any ideas or suggestions for how to resolve these issues would be greatly appreciated.

This implementation takes advantage of `napi-rs` [ThreadsafeFunction](https://napi.rs/docs/concepts/threadsafe-function) because JS data is restricted to the main thread, the Rust processing is mostly happening on background threads. This queues any requested invocations and waits for the main thread to become available (effectively adding the call to the JS event queue). Once ready, the JS function is invoked. The return value is dropped as [`napi-rs` doesn't seem to do anything with it](https://github.com/napi-rs/napi-rs/blob/548f358fdbaeba43be4a91aaec3b411a404ffb61/crates/napi/src/threadsafe_function.rs#L400), however Parcel passes in a callback function for the JS to invoke with the result, using Node callback conventions (`callback(err, result)`). This means the _actual_ JS contract is:

```typescript
function read(file: string, cb: (err: any, result: string) => void): void {
  fs.readFile(file, 'utf-8').then(
    (res) => cb(null, res),
    (err) => cb(err, null),
  );
}

function resolve(specifier: string, originatingFile: string, cb: (err: any, result: string) => void): void {
  cb(null, path.join(originatingFile, '..', specifier));
}
```

This is unergonomic, so a small JS shim wraps the Rust implementation of `bundleAsync()` and converts this contract to the `Promise`-based one mentioned earlier. This makes custom resolvers much easier to use while still adhering to `napi-rs`' required calling conventions.

I included tests for the new behavior, though there doesn't seem to be much existing JS test infrastructure, so it's a bit primitive for now and mostly aligns with the existing JS test of `transform()`. They can be executed with `npm run build && node test-bundle.js`. Not sure if there's a better setup for this.

`bundle()` is unaffected because communicating between threads in a synchronous-compatible manner is quite tricky and not in-scope here. However, it does throw if given a `resolver`, since that's indicative of user-error.