### PR TITLE
Show errors in playground

### DIFF
--- a/playground/playground.js
+++ b/playground/playground.js
@@ -133,32 +133,38 @@ function update() {
   const {transform} = wasm;
 
   const targets = getTargets();
-  let res = transform({
-    filename: 'test.css',
-    code: enc.encode(source.value),
-    minify: minify.checked,
-    targets: Object.keys(targets).length === 0 ? null : targets,
-    drafts: {
-      nesting: nesting.checked,
-      customMedia: customMedia.checked
-    },
-    cssModules: cssModules.checked,
-    analyzeDependencies: analyzeDependencies.checked,
-    unusedSymbols: unusedSymbols.value.split('\n').map(v => v.trim()).filter(Boolean)
-  });
+  try {
+    let res = transform({
+      filename: 'test.css',
+      code: enc.encode(source.value),
+      minify: minify.checked,
+      targets: Object.keys(targets).length === 0 ? null : targets,
+      drafts: {
+        nesting: nesting.checked,
+        customMedia: customMedia.checked
+      },
+      cssModules: cssModules.checked,
+      analyzeDependencies: analyzeDependencies.checked,
+      unusedSymbols: unusedSymbols.value.split('\n').map(v => v.trim()).filter(Boolean)
+    });
 
-  compiled.value = dec.decode(res.code);
-  compiledModules.value = JSON.stringify(res.exports, false, 2);
-  compiledModules.hidden = !cssModules.checked;
-  compiledDependencies.value = JSON.stringify(res.dependencies, false, 2);
-  compiledDependencies.hidden = !analyzeDependencies.checked;
+    compiled.value = dec.decode(res.code);
+    compiled.style.color = "initial";
+    compiledModules.value = JSON.stringify(res.exports, false, 2);
+    compiledModules.hidden = !cssModules.checked;
+    compiledDependencies.value = JSON.stringify(res.dependencies, false, 2);
+    compiledDependencies.hidden = !analyzeDependencies.checked;
+  } catch(e) {
+    compiled.value = e.message;
+    compiled.style.color = "red";
+  }
 
   savePlaygroundState();
 }
 
 async function main() {
-  await loadVersions();
   loadPlaygroundState();
+  await loadVersions();
   await loadWasm();
 
   update();


### PR DESCRIPTION
- Show errors in the playground (changing the text color to red)
- Stores the current playground state in the URL even if the transform failed
- (Run `loadPlaygroundState` after `await loadVersions()` because the former is synchronous)

<img width="1427" alt="Bildschirmfoto 2022-06-08 um 10 36 18" src="https://user-images.githubusercontent.com/4586894/172571469-4b218ac2-3a6b-4fda-b7a1-f19f016e49ef.png">
