### PR TITLE
set `libc` field to glibc in package.json targeting gnu

### DIFF
--- a/scripts/build-npm.js
+++ b/scripts/build-npm.js
@@ -24,6 +24,9 @@ const sysToNodePlatform = {
   darwin: 'darwin',
   windows: 'win32',
 };
+const abiToNodeLibc = {
+  gnu: 'glibc',
+};
 
 let optionalDependencies = {};
 let cliOptionalDependencies = {};
@@ -76,7 +79,7 @@ function buildNode(triple, cpu, os, abi, t) {
   pkg2.os = [os];
   pkg2.cpu = [cpu];
   if (abi) {
-    pkg2.libc = [abi];
+    pkg2.libc = [abiToNodeLibc[abi] || abi];
   }
   pkg2.main = name;
   pkg2.files = [name];
@@ -106,7 +109,7 @@ function buildCLI(triple, cpu, os, abi, t) {
   pkg2.cpu = [cpu];
   pkg2.files = [binary];
   if (abi) {
-    pkg2.libc = [abi];
+    pkg2.libc = [abiToNodeLibc[abi] || abi];
   }
   delete pkg2.main;
   delete pkg2.napi;


### PR DESCRIPTION
fixes #203

> To avoid this, Yarn now supports a libc array field in the package.json that currently accepts any of two values: glibc and musl. Just like os and cpu, packages will be skipped if they don't match the host libc.
> -- https://dev.to/arcanis/yarn-32-libc-yarn-explain-next-major--o22

Yarn, cnpm, and pnpm will filter optionalDependencies with abi as well, which only understands gcc abi with the name `glibc`, yet `-gnu` is a well conceived abi naming in napi packages. Hence manually set `libc` field to `[ "glibc" ]`.