### PR TITLE
Remove `pkg.libc` property for Windows

### DIFF
--- a/scripts/build-npm.js
+++ b/scripts/build-npm.js
@@ -75,7 +75,7 @@ function buildNode(triple, cpu, os, abi, t) {
   pkg2.name += '-' + t;
   pkg2.os = [os];
   pkg2.cpu = [cpu];
-  if (abi) {
+  if (abi && os !== "win32") {
     pkg2.libc = [abi];
   }
   pkg2.main = name;
@@ -105,7 +105,7 @@ function buildCLI(triple, cpu, os, abi, t) {
   pkg2.os = [os];
   pkg2.cpu = [cpu];
   pkg2.files = [binary];
-  if (abi) {
+  if (abi && os !== "win32") {
     pkg2.libc = [abi];
   }
   delete pkg2.main;


### PR DESCRIPTION
Closes #207

Currently Yarn >=2 doesn't install the Windows specific optional package at all.

See https://github.com/parcel-bundler/parcel-css/issues/207#issuecomment-1157479514