### PR TITLE
Merge adjacent layers with the same name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6471,7 +6471,42 @@ mod tests {
       },
     );
   }
+  #[test]
+  fn test_merge_layers() {
+    test(
+      r#"
+      @layer foo {
+        .foo {
+          color: red;
+        }
+      }
+      @layer foo {
+        .bar {
+          background: #fff;
+        }
 
+        .baz {
+          color: #fff;
+        }
+      }
+      "#,
+      indoc! {r#"
+      @layer foo {
+        .foo {
+          color: red;
+        }
+
+        .bar {
+          background: #fff;
+        }
+
+        .baz {
+          color: #fff;
+        }
+      }
+    "#},
+    );
+  }
   #[test]
   fn test_merge_rules() {
     test(

--- a/src/rules/layer.rs
+++ b/src/rules/layer.rs
@@ -1,7 +1,7 @@
 //! The `@layer` rule.
 
-use super::{CssRuleList, Location};
-use crate::error::{ParserError, PrinterError};
+use super::{CssRuleList, Location, MinifyContext};
+use crate::error::{MinifyError, ParserError, PrinterError};
 use crate::printer::Printer;
 use crate::traits::{Parse, ToCss};
 use crate::values::string::CowArcStr;
@@ -111,6 +111,18 @@ pub struct LayerBlockRule<'i> {
   pub rules: CssRuleList<'i>,
   /// The location of the rule in the source file.
   pub loc: Location,
+}
+
+impl<'i> LayerBlockRule<'i> {
+  pub(crate) fn minify(
+    &mut self,
+    context: &mut MinifyContext<'_, 'i>,
+    parent_is_unused: bool,
+  ) -> Result<bool, MinifyError> {
+    self.rules.minify(context, parent_is_unused)?;
+
+    Ok(self.rules.0.is_empty())
+  }
 }
 
 impl<'i> ToCss for LayerBlockRule<'i> {

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -301,6 +301,16 @@ impl<'i> CssRuleList<'i> {
             continue;
           }
         }
+        CssRule::LayerBlock(layer) => {
+          if let Some(CssRule::LayerBlock(last_style_rule)) = rules.last_mut() {
+            if last_style_rule.name == layer.name {
+              last_style_rule.rules.0.extend(layer.rules.0.drain(..));
+            }
+            if layer.minify(context, parent_is_unused)? {
+              continue;
+            }
+          }
+        }
         CssRule::MozDocument(document) => document.minify(context)?,
         CssRule::Style(style) => {
           if parent_is_unused || style.minify(context, parent_is_unused)? {


### PR DESCRIPTION
Fixes #211

Literally installed Rust a few hours ago, "please go read a Rust tutorial first" is a valid reply and I'd be happy to do another round :)

I'll probably need to do that to implement my other suggestion about hoisting layers. Adjacent style rules are also not merged inside layers, but that's not a regression. I guess it needs another pass of `minify`?