### PR TITLE
fix: support importing via ES modules

### DIFF
--- a/node/index.mjs
+++ b/node/index.mjs
@@ -1,0 +1,32 @@
+let parts = [process.platform, process.arch];
+if (process.platform === 'linux') {
+  const {MUSL, family} = await import('detect-libc');
+  if (family === MUSL) {
+    parts.push('musl');
+  } else if (process.arch === 'arm') {
+    parts.push('gnueabihf');
+  } else {
+    parts.push('gnu');
+  }
+} else if (process.platform === 'win32') {
+  parts.push('msvc');
+}
+
+let default_export;
+if (process.env.CSS_TRANSFORMER_WASM) {
+  default_export = await import('./pkg/parcel_css_node.js');
+} else {
+  const {createRequire} = await import('module');
+  const require = createRequire(import.meta.url);
+
+  try {
+    default_export = require(`@parcel/css-${parts.join('-')}`);
+  } catch (err) {
+    default_export = require(`../parcel-css.${parts.join('-')}.node`);
+  }
+}
+
+export default default_export;
+
+import browserslistToTargetsImport from './browserslistToTargets.js';
+export const browserslistToTargets = browserslistToTargetsImport;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@napi-rs/cli": "^2.6.2",
     "autoprefixer": "^10.4.4",
     "caniuse-lite": "^1.0.30001319",
+    "cross-env": "^7.0.3",
     "cssnano": "^5.0.8",
     "esbuild": "^0.13.10",
     "jest-diff": "^27.4.2",
@@ -48,10 +49,10 @@
     "puppeteer": "^12.0.1"
   },
   "scripts": {
-    "build": "node scripts/build.js && node scripts/build-flow.js",
+    "build": "node scripts/build.js && node scripts/build-flow.js && node ./tests/import-test.mjs",
     "build-release": "node scripts/build.js --release && node scripts/build-flow.js",
     "prepublishOnly": "node scripts/build-flow.js",
-    "wasm:build": "wasm-pack build node --target nodejs",
+    "wasm:build": "wasm-pack build node --target nodejs && cross-env CSS_TRANSFORMER_WASM=1 node ./tests/import-test.mjs",
     "wasm:build-release": "wasm-pack build node --target nodejs --release",
     "wasm-browser:build": "wasm-pack build node --target web",
     "wasm-browser:build-release": "wasm-pack build node --target web --release",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "description": "A CSS parser, transformer, and minifier written in Rust",
   "main": "node/index.js",
   "types": "node/index.d.ts",
+  "exports": {
+    "require": "./node/index.js",
+    "import": "./node/index.mjs"
+  },
   "targets": {
     "main": false,
     "types": false

--- a/tests/import-test.mjs
+++ b/tests/import-test.mjs
@@ -1,0 +1,7 @@
+import assert from 'assert';
+
+import css from '../node/index.mjs';
+import {browserslistToTargets} from '../node/index.mjs';
+
+assert(typeof css === 'object');
+assert(typeof browserslistToTargets === 'function');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1614,6 +1614,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^6.0.4:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -1624,6 +1631,15 @@ cross-spawn@^6.0.4:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+cross-spawn@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
 
 crypto-browserify@^3.12.0:
   version "3.12.0"
@@ -3608,6 +3624,11 @@ path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
 path-to-regexp@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.2.1.tgz#90b617025a16381a879bc82a38d4e8bdeb2bcf45"
@@ -4370,10 +4391,22 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -4953,6 +4986,13 @@ which@^1.2.9:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
This allows using parcel-css from ES modules. Some build tools (e.g. Astro) require ES modules.