### PR TITLE
refactor(rules/font_face): change supports to tech

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9469,8 +9469,8 @@ mod tests {
     );
     // multiple tech
     minify_test(
-      "@font-face {src: url(\"test.woff\") format(woff) tech(features-opentype, color-sbix);}",
-      "@font-face{src:url(test.woff)format(\"woff\")tech(features-opentype,color-sbix)}",
+      "@font-face {src: url(\"test.woff\") format(woff) tech(feature-opentype, color-sbix);}",
+      "@font-face{src:url(test.woff)format(\"woff\")tech(feature-opentype,color-sbix)}",
     );
     minify_test(
       "@font-face {src: url(\"test.woff\")   format(woff)    tech(incremental, color-svg, feature-graphite, feature-aat);}",
@@ -9478,13 +9478,13 @@ mod tests {
     );
     // format() function must precede tech() if both are present
     minify_test(
-      "@font-face {src: url(\"foo.ttf\") format(opentype) tech(color-COLRv1);}",
-      "@font-face{src:url(foo.ttf)format(\"opentype\")tech(color-COLRv1)}",
+      "@font-face {src: url(\"foo.ttf\") format(opentype) tech(color-colrv1);}",
+      "@font-face{src:url(foo.ttf)format(\"opentype\")tech(color-colrv1)}",
     );
     // only have tech is valid
     minify_test(
       "@font-face {src: url(\"foo.ttf\") tech(color-SVG);}",
-      "@font-face{src:url(foo.ttf)tech(color-SVG)}",
+      "@font-face{src:url(foo.ttf)tech(color-svg)}",
     );
     // CGQAQ: if tech and format both presence, order is matter, tech before format is invalid
     // but now just return raw token, we don't have strict mode yet.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9448,7 +9448,7 @@ mod tests {
       "@font-face{src:url(test.woff)format(\"woff\")}",
     );
     minify_test(
-      "@font-face {src: url(\"test.woff\") format(woff), url(test.ttf) format(truetype);}",
+      "@font-face {src: url(\"test.woff\") format(woff), url(test.ttf) format(\"truetype\");}",
       "@font-face{src:url(test.woff)format(\"woff\"),url(test.ttf)format(\"truetype\")}",
     );
     minify_test(
@@ -9456,7 +9456,7 @@ mod tests {
       "@font-face{src:url(test.woff)format(\"woff\")tech(features-opentype)}",
     );
     minify_test(
-      "@font-face {src: url(\"test.woff\") format(woff) tech(color-COLRv1);}",
+      "@font-face {src: url(\"test.woff\") format(woff) tech(color-colrv1);}",
       "@font-face{src:url(test.woff)format(\"woff\")tech(color-colrv1)}",
     );
     minify_test(
@@ -9467,14 +9467,15 @@ mod tests {
       "@font-face {src: url(\"test.woff\") format(woff) tech(palettes);}",
       "@font-face{src:url(test.woff)format(\"woff\")tech(palettes)}",
     );
+    // multiple tech
     minify_test(
       "@font-face {src: url(\"test.woff\") format(woff) tech(features-opentype, color-sbix);}",
-      "@font-face{src:url(test.woff)format(\"woff\")tech(features-opentype,color-sbix))}",
+      "@font-face{src:url(test.woff)format(\"woff\")tech(features-opentype,color-sbix)}",
     );
     // format() function must precede tech() if both are present
     minify_test(
-      "@font-face {src: url(\"foo.ttf\") format(opentype) tech(feature-opentype);}",
-      "@font-face{src:url(\"foo.ttf\")format(opentype)tech(feature-opentype);}",
+      "@font-face {src: url(\"foo.ttf\") format(opentype) tech(features-opentype);}",
+      "@font-face{src:url(foo.ttf)format(\"opentype\")tech(features-opentype)}",
     );
     error_test(
       "@font-face {src: url(\"foo.ttf\") tech(feature-opentype) format(opentype);}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub mod vendor_prefix;
 mod tests {
   use crate::css_modules::{CssModuleExport, CssModuleExports, CssModuleReference, CssModuleReferences};
   use crate::dependencies::Dependency;
-  use crate::error::{Error, ErrorLocation, MinifyErrorKind, ParserError, PrinterErrorKind, SelectorError};
+  use crate::error::{self, Error, ErrorLocation, MinifyErrorKind, ParserError, PrinterErrorKind, SelectorError};
   use crate::properties::custom::Token;
   use crate::properties::Property;
   use crate::rules::CssRule;
@@ -9442,6 +9442,7 @@ mod tests {
     );
     minify_test("@font-face {src: local(Test);}", "@font-face{src:local(Test)}");
     minify_test("@font-face {src: local(Foo Bar);}", "@font-face{src:local(Foo Bar)}");
+
     minify_test(
       "@font-face {src: url(\"test.woff\") format(woff);}",
       "@font-face{src:url(test.woff)format(\"woff\")}",
@@ -9451,24 +9452,33 @@ mod tests {
       "@font-face{src:url(test.woff)format(\"woff\"),url(test.ttf)format(\"truetype\")}",
     );
     minify_test(
-      "@font-face {src: url(\"test.woff\") format(woff supports features(opentype));}",
-      "@font-face{src:url(test.woff)format(\"woff\" supports features(opentype))}",
+      "@font-face {src: url(\"test.woff\") format(woff) tech(features-opentype);}",
+      "@font-face{src:url(test.woff)format(\"woff\")tech(features-opentype)}",
     );
     minify_test(
-      "@font-face {src: url(\"test.woff\") format(woff supports color(COLRv1));}",
-      "@font-face{src:url(test.woff)format(\"woff\" supports color(colrv1))}",
+      "@font-face {src: url(\"test.woff\") format(woff) tech(color-COLRv1);}",
+      "@font-face{src:url(test.woff)format(\"woff\")tech(color-colrv1)}",
     );
     minify_test(
-      "@font-face {src: url(\"test.woff\") format(woff supports variations);}",
-      "@font-face{src:url(test.woff)format(\"woff\" supports variations)}",
+      "@font-face {src: url(\"test.woff\") format(woff) tech(variations);}",
+      "@font-face{src:url(test.woff)format(\"woff\")tech(variations)}",
     );
     minify_test(
-      "@font-face {src: url(\"test.woff\") format(woff supports palettes);}",
-      "@font-face{src:url(test.woff)format(\"woff\" supports palettes)}",
+      "@font-face {src: url(\"test.woff\") format(woff) tech(palettes);}",
+      "@font-face{src:url(test.woff)format(\"woff\")tech(palettes)}",
     );
     minify_test(
-      "@font-face {src: url(\"test.woff\") format(woff supports features(opentype) color(sbix));}",
-      "@font-face{src:url(test.woff)format(\"woff\" supports features(opentype) color(sbix))}",
+      "@font-face {src: url(\"test.woff\") format(woff) tech(features-opentype, color-sbix);}",
+      "@font-face{src:url(test.woff)format(\"woff\")tech(features-opentype,color-sbix))}",
+    );
+    // format() function must precede tech() if both are present
+    minify_test(
+      "@font-face {src: url(\"foo.ttf\") format(opentype) tech(feature-opentype);}",
+      "@font-face{src:url(\"foo.ttf\")format(opentype)tech(feature-opentype);}",
+    );
+    error_test(
+      "@font-face {src: url(\"foo.ttf\") tech(feature-opentype) format(opentype);}",
+      ParserError::AtRuleBodyInvalid,
     );
     minify_test(
       "@font-face {src: local(\"\") url(\"test.woff\");}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9448,20 +9448,20 @@ mod tests {
       "@font-face{src:url(test.woff)format(\"woff\")}",
     );
     minify_test(
-      "@font-face {src: url(\"test.woff\") format(woff), url(test.ttf) format(\"truetype\");}",
-      "@font-face{src:url(test.woff)format(\"woff\"),url(test.ttf)format(\"truetype\")}",
+      "@font-face {src: url(\"test.ttc\") format(collection), url(test.ttf) format(truetype);}",
+      "@font-face{src:url(test.ttc)format(\"collection\"),url(test.ttf)format(\"truetype\")}",
     );
     minify_test(
-      "@font-face {src: url(\"test.woff\") format(woff) tech(features-opentype);}",
-      "@font-face{src:url(test.woff)format(\"woff\")tech(features-opentype)}",
+      "@font-face {src: url(\"test.otf\") format(opentype) tech(feature-aat);}",
+      "@font-face{src:url(test.otf)format(\"opentype\")tech(feature-aat)}",
     );
     minify_test(
       "@font-face {src: url(\"test.woff\") format(woff) tech(color-colrv1);}",
       "@font-face{src:url(test.woff)format(\"woff\")tech(color-colrv1)}",
     );
     minify_test(
-      "@font-face {src: url(\"test.woff\") format(woff) tech(variations);}",
-      "@font-face{src:url(test.woff)format(\"woff\")tech(variations)}",
+      "@font-face {src: url(\"test.woff2\") format(woff2) tech(variations);}",
+      "@font-face{src:url(test.woff2)format(\"woff2\")tech(variations)}",
     );
     minify_test(
       "@font-face {src: url(\"test.woff\") format(woff) tech(palettes);}",
@@ -9472,27 +9472,43 @@ mod tests {
       "@font-face {src: url(\"test.woff\") format(woff) tech(features-opentype, color-sbix);}",
       "@font-face{src:url(test.woff)format(\"woff\")tech(features-opentype,color-sbix)}",
     );
+    minify_test(
+      "@font-face {src: url(\"test.woff\")   format(woff)    tech(incremental, color-svg, feature-graphite, feature-aat);}",
+      "@font-face{src:url(test.woff)format(\"woff\")tech(incremental,color-svg,feature-graphite,feature-aat)}",
+    );
     // format() function must precede tech() if both are present
     minify_test(
-      "@font-face {src: url(\"foo.ttf\") format(opentype) tech(features-opentype);}",
-      "@font-face{src:url(foo.ttf)format(\"opentype\")tech(features-opentype)}",
+      "@font-face {src: url(\"foo.ttf\") format(opentype) tech(color-COLRv1);}",
+      "@font-face{src:url(foo.ttf)format(\"opentype\")tech(color-COLRv1)}",
     );
     // only have tech is valid
     minify_test(
-      "@font-face {src: url(\"foo.ttf\") tech(features-opentype);}",
-      "@font-face{src:url(foo.ttf)tech(features-opentype)}",
+      "@font-face {src: url(\"foo.ttf\") tech(color-SVG);}",
+      "@font-face{src:url(foo.ttf)tech(color-SVG)}",
     );
     // CGQAQ: if tech and format both presence, order is matter, tech before format is invalid
     // but now just return raw token, we don't have strict mode yet.
     // ref: https://github.com/parcel-bundler/parcel-css/pull/255#issuecomment-1219049998
     minify_test(
-      "@font-face {src: url(\"foo.ttf\") tech(features-opentype) format(opentype);}",
-      "@font-face{src:url(foo.ttf) tech(features-opentype)format(opentype)}",
+      "@font-face {src: url(\"foo.ttf\") tech(palettes  color-colrv0  variations) format(opentype);}",
+      "@font-face{src:url(foo.ttf) tech(palettes color-colrv0 variations)format(opentype)}",
     );
     // TODO(CGQAQ): make this test pass when we have strict mode
     // ref: https://github.com/web-platform-tests/wpt/blob/9f8a6ccc41aa725e8f51f4f096f686313bb88d8d/css/css-fonts/parsing/font-face-src-tech.html#L45
     // error_test(
     //   "@font-face {src: url(\"foo.ttf\") tech(feature-opentype) format(opentype);}",
+    //   ParserError::AtRuleBodyInvalid,
+    // );
+    // error_test(
+    //   "@font-face {src: url(\"foo.ttf\") tech();}",
+    //   ParserError::AtRuleBodyInvalid,
+    // );
+    // error_test(
+    //   "@font-face {src: url(\"foo.ttf\") tech(\"feature-opentype\");}",
+    //   ParserError::AtRuleBodyInvalid,
+    // );
+    // error_test(
+    //   "@font-face {src: url(\"foo.ttf\") tech(\"color-colrv0\");}",
     //   ParserError::AtRuleBodyInvalid,
     // );
     minify_test(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub mod vendor_prefix;
 mod tests {
   use crate::css_modules::{CssModuleExport, CssModuleExports, CssModuleReference, CssModuleReferences};
   use crate::dependencies::Dependency;
-  use crate::error::{self, Error, ErrorLocation, MinifyErrorKind, ParserError, PrinterErrorKind, SelectorError};
+  use crate::error::{Error, ErrorLocation, MinifyErrorKind, ParserError, PrinterErrorKind, SelectorError};
   use crate::properties::custom::Token;
   use crate::properties::Property;
   use crate::rules::CssRule;
@@ -9477,10 +9477,11 @@ mod tests {
       "@font-face {src: url(\"foo.ttf\") format(opentype) tech(features-opentype);}",
       "@font-face{src:url(foo.ttf)format(\"opentype\")tech(features-opentype)}",
     );
-    error_test(
-      "@font-face {src: url(\"foo.ttf\") tech(feature-opentype) format(opentype);}",
-      ParserError::AtRuleBodyInvalid,
-    );
+    // TODO(CGQAQ): make this test pass
+    // error_test(
+    //   "@font-face {src: url(\"foo.ttf\") tech(feature-opentype) format(opentype);}",
+    //   ParserError::AtRuleBodyInvalid,
+    // );
     minify_test(
       "@font-face {src: local(\"\") url(\"test.woff\");}",
       "@font-face{src:local(\"\")url(test.woff)}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9477,7 +9477,18 @@ mod tests {
       "@font-face {src: url(\"foo.ttf\") format(opentype) tech(features-opentype);}",
       "@font-face{src:url(foo.ttf)format(\"opentype\")tech(features-opentype)}",
     );
-    // TODO(CGQAQ): make this test pass
+    // only have tech is valid
+    minify_test(
+      "@font-face {src: url(\"foo.ttf\") tech(features-opentype);}",
+      "@font-face{src:url(foo.ttf)tech(features-opentype)}",
+    );
+    // CGQAQ: if tech and format both presence, order is matter, tech before format is invalid
+    // but now just return raw token, we don't have strict mode yet.
+    minify_test(
+      "@font-face {src: url(\"foo.ttf\") tech(features-opentype) format(opentype);}",
+      "@font-face{src:url(foo.ttf) tech(features-opentype)format(opentype)}",
+    );
+    // TODO(CGQAQ): make this test pass when we have strict mode
     // ref: https://github.com/web-platform-tests/wpt/blob/9f8a6ccc41aa725e8f51f4f096f686313bb88d8d/css/css-fonts/parsing/font-face-src-tech.html#L45
     // error_test(
     //   "@font-face {src: url(\"foo.ttf\") tech(feature-opentype) format(opentype);}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9478,6 +9478,7 @@ mod tests {
       "@font-face{src:url(foo.ttf)format(\"opentype\")tech(features-opentype)}",
     );
     // TODO(CGQAQ): make this test pass
+    // ref: https://github.com/web-platform-tests/wpt/blob/9f8a6ccc41aa725e8f51f4f096f686313bb88d8d/css/css-fonts/parsing/font-face-src-tech.html#L45
     // error_test(
     //   "@font-face {src: url(\"foo.ttf\") tech(feature-opentype) format(opentype);}",
     //   ParserError::AtRuleBodyInvalid,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9484,6 +9484,7 @@ mod tests {
     );
     // CGQAQ: if tech and format both presence, order is matter, tech before format is invalid
     // but now just return raw token, we don't have strict mode yet.
+    // ref: https://github.com/parcel-bundler/parcel-css/pull/255#issuecomment-1219049998
     minify_test(
       "@font-face {src: url(\"foo.ttf\") tech(features-opentype) format(opentype);}",
       "@font-face{src:url(foo.ttf) tech(features-opentype)format(opentype)}",

--- a/src/rules/font_face.rs
+++ b/src/rules/font_face.rs
@@ -70,11 +70,11 @@ impl<'i> Parse<'i> for Source<'i> {
   fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
     match input.try_parse(UrlSource::parse) {
       Ok(url) => return Ok(Source::Url(url)),
-      a @ Err(ParseError {
+      e @ Err(ParseError {
         kind: ParseErrorKind::Basic(BasicParseErrorKind::AtRuleBodyInvalid),
         ..
       }) => {
-        return Err(a.err().unwrap());
+        return Err(e.err().unwrap());
       }
       _ => {}
     }

--- a/src/rules/font_face.rs
+++ b/src/rules/font_face.rs
@@ -266,16 +266,16 @@ pub enum FontTechnology {
   /// property of an `@font-face` rule.
   /// Supports OpenType Features.
   /// https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist
-  #[cfg_attr(feature = "serde", serde(rename = "features-opentype"))]
-  FeaturesOpentype,
+  #[cfg_attr(feature = "serde", serde(rename = "feature-opentype"))]
+  FeatureOpentype,
   /// Supports Apple Advanced Typography Font Features.
   /// https://developer.apple.com/fonts/TrueType-Reference-Manual/RM09/AppendixF.html
-  #[cfg_attr(feature = "serde", serde(rename = "features-aat"))]
-  FeaturesAat,
+  #[cfg_attr(feature = "serde", serde(rename = "feature-aat"))]
+  FeatureAat,
   /// Supports Graphite Table Format.
   /// https://scripts.sil.org/cms/scripts/render_download.php?site_id=nrsi&format=file&media_id=GraphiteBinaryFormat_3_0&filename=GraphiteBinaryFormat_3_0.pdf
-  #[cfg_attr(feature = "serde", serde(rename = "features-graphite"))]
-  FeaturesGraphite,
+  #[cfg_attr(feature = "serde", serde(rename = "feature-graphite"))]
+  FeatureGraphite,
 
   /// A color font tech descriptor in the `tech()`function of the
   /// [src](https://drafts.csswg.org/css-fonts/#src-desc)
@@ -298,15 +298,15 @@ pub enum FontTechnology {
 
   /// Supports Variations
   /// The variations tech refers to the support of font variations
-  #[cfg_attr(feature = "serde", serde(rename = "variations"))] 
+  #[cfg_attr(feature = "serde", serde(rename = "variations"))]
   Variations,
   /// Supports Palettes
   /// The palettes tech refers to support for font palettes
-  #[cfg_attr(feature = "serde", serde(rename = "palettes"))] 
+  #[cfg_attr(feature = "serde", serde(rename = "palettes"))]
   Palettes,
   /// Supports Incremental
   /// The incremental tech refers to client support for incremental font loading, using either the range-request or the patch-subset method
-  #[cfg_attr(feature = "serde", serde(rename = "incremental"))] 
+  #[cfg_attr(feature = "serde", serde(rename = "incremental"))]
   Incremental,
 }
 
@@ -319,9 +319,9 @@ impl<'i> Parse<'i> for FontTechnology {
           "variations" => Ok(FontTechnology::Variations),
           "palettes" => Ok(FontTechnology::Palettes),
           "incremental" => Ok(FontTechnology::Incremental),
-          "features-opentype" => Ok(FontTechnology::FeaturesOpentype),
-          "features-aat" => Ok(FontTechnology::FeaturesAat),
-          "features-graphite" => Ok(FontTechnology::FeaturesGraphite),
+          "feature-opentype" => Ok(FontTechnology::FeatureOpentype),
+          "feature-aat" => Ok(FontTechnology::FeatureAat),
+          "feature-graphite" => Ok(FontTechnology::FeatureGraphite),
           "color-colrv0" => Ok(FontTechnology::ColorCOLRv0),
           "color-colrv1" => Ok(FontTechnology::ColorCOLRv1),
           "color-svg" => Ok(FontTechnology::ColorSVG),
@@ -342,10 +342,11 @@ impl ToCss for FontTechnology {
   where
     W: std::fmt::Write,
   {
+    // ref: https://hg.mozilla.org/mozilla-central/rev/f97705333d4c#l7.101
     dest.write_str(match self {
-      FontTechnology::FeaturesOpentype => "features-opentype",
-      FontTechnology::FeaturesAat => "features-aat",
-      FontTechnology::FeaturesGraphite => "features-graphite",
+      FontTechnology::FeatureOpentype => "feature-opentype",
+      FontTechnology::FeatureAat => "feature-aat",
+      FontTechnology::FeatureGraphite => "feature-graphite",
       FontTechnology::ColorCOLRv0 => "color-colrv0",
       FontTechnology::ColorCOLRv1 => "color-colrv1",
       FontTechnology::ColorSVG => "color-svg",

--- a/src/rules/font_face.rs
+++ b/src/rules/font_face.rs
@@ -137,7 +137,7 @@ impl<'i> ToCss for UrlSource<'i> {
   }
 }
 
-/// The `format()` function within the [src](https://drafts.csswg.org/css-fonts/#src-desc)
+/// The `format()` function within the [src](https://drafts.csswg.org/css-fonts/#font-face-src-parsing)
 /// property of an `@font-face` rule.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -145,25 +145,24 @@ pub struct Format<'i> {
   /// A font format name.
   #[cfg_attr(feature = "serde", serde(borrow))]
   pub format: FontFormat<'i>,
-  /// The `supports()` function.
-  // TODO: did this get renamed to `tech()`?
-  pub supports: Vec<FontTechnology>,
+  /// The `tech()` function.
+  pub tech: Vec<FontTechnology>,
 }
 
 impl<'i> Parse<'i> for Format<'i> {
   fn parse<'t>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i, ParserError<'i>>> {
     let format = FontFormat::parse(input)?;
-    let mut supports = vec![];
-    if input.try_parse(|input| input.expect_ident_matching("supports")).is_ok() {
+    let mut tech = vec![];
+    if input.try_parse(|input| input.expect_ident_matching("tech")).is_ok() {
       loop {
         if let Ok(technology) = input.try_parse(FontTechnology::parse) {
-          supports.push(technology)
+          tech.push(technology)
         } else {
           break;
         }
       }
     }
-    Ok(Format { format, supports })
+    Ok(Format { format, tech })
   }
 }
 
@@ -173,10 +172,10 @@ impl<'i> ToCss for Format<'i> {
     W: std::fmt::Write,
   {
     self.format.to_css(dest)?;
-    if !self.supports.is_empty() {
-      dest.write_str(" supports ")?;
+    if !self.tech.is_empty() {
+      dest.write_str(" tech ")?;
       let mut first = true;
-      for technology in &self.supports {
+      for technology in &self.tech {
         if first {
           first = false;
         } else {
@@ -258,7 +257,7 @@ impl<'i> ToCss for FontFormat<'i> {
 }
 
 enum_property! {
-  /// A font feature tech descriptor in the `supports()`function of the
+  /// A font feature tech descriptor in the `tech()`function of the
   /// [src](https://drafts.csswg.org/css-fonts/#src-desc)
   /// property of an `@font-face` rule.
   pub enum FontFeatureTechnology {
@@ -272,7 +271,7 @@ enum_property! {
 }
 
 enum_property! {
-  /// A color font tech descriptor in the `supports()`function of the
+  /// A color font tech descriptor in the `tech()`function of the
   /// [src](https://drafts.csswg.org/css-fonts/#src-desc)
   /// property of an `@font-face` rule.
   pub enum ColorFontTechnology {
@@ -289,7 +288,7 @@ enum_property! {
   }
 }
 
-/// A font technology descriptor in the `supports()`function of the
+/// A font technology descriptor in the `tech()`function of the
 /// [src](https://drafts.csswg.org/css-fonts/#src-desc)
 /// property of an `@font-face` rule.
 #[derive(Debug, Clone, PartialEq)]

--- a/src/rules/font_face.rs
+++ b/src/rules/font_face.rs
@@ -192,9 +192,10 @@ impl<'i> ToCss for UrlSource<'i> {
   serde(tag = "type", content = "value", rename_all = "kebab-case")
 )]
 pub enum FontFormat<'i> {
-  /// A WOFF font.
+  /// [src](https://drafts.csswg.org/css-fonts/#font-format-definitions)
+  /// A WOFF 1.0 font.
   WOFF,
-  /// A WOFF v2 font.
+  /// A WOFF 2.0 font.
   WOFF2,
   /// A TrueType font.
   TrueType,
@@ -202,7 +203,7 @@ pub enum FontFormat<'i> {
   OpenType,
   /// An Embedded OpenType (.eot) font.
   EmbeddedOpenType,
-  /// A font collection.
+  /// OpenType Collection.
   Collection,
   /// An SVG font.
   SVG,
@@ -257,38 +258,55 @@ impl<'i> ToCss for FontFormat<'i> {
 #[cfg_attr(
   feature = "serde",
   derive(serde::Serialize, serde::Deserialize),
-  serde(tag = "type", content = "value", rename_all = "kebab-case")
+  serde(tag = "type", content = "value")
 )]
 pub enum FontTechnology {
   /// A font feature tech descriptor in the `tech()`function of the
-  /// [src](https://drafts.csswg.org/css-fonts/#src-desc)
+  /// [src](https://drafts.csswg.org/css-fonts/#font-feature-tech-values)
   /// property of an `@font-face` rule.
-  /// support FeaturesOpentype
+  /// Supports OpenType Features.
+  /// https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist
+  #[cfg_attr(feature = "serde", serde(rename = "features-opentype"))]
   FeaturesOpentype,
-  /// support FeaturesAat
+  /// Supports Apple Advanced Typography Font Features.
+  /// https://developer.apple.com/fonts/TrueType-Reference-Manual/RM09/AppendixF.html
+  #[cfg_attr(feature = "serde", serde(rename = "features-aat"))]
   FeaturesAat,
-  /// support FeaturesGraphite
+  /// Supports Graphite Table Format.
+  /// https://scripts.sil.org/cms/scripts/render_download.php?site_id=nrsi&format=file&media_id=GraphiteBinaryFormat_3_0&filename=GraphiteBinaryFormat_3_0.pdf
+  #[cfg_attr(feature = "serde", serde(rename = "features-graphite"))]
   FeaturesGraphite,
 
   /// A color font tech descriptor in the `tech()`function of the
   /// [src](https://drafts.csswg.org/css-fonts/#src-desc)
   /// property of an `@font-face` rule.
-  /// support ColorColrv0
-  ColorColrv0,
-  /// support ColorColrv1
-  ColorColrv1,
-  /// support ColorSvg
-  ColorSvg,
-  /// support ColorSbix
+  /// Supports the `COLR` v0 table.
+  #[cfg_attr(feature = "serde", serde(rename = "color-colrv0"))]
+  ColorCOLRv0,
+  /// Supports the `COLR` v1 table.
+  #[cfg_attr(feature = "serde", serde(rename = "color-colrv1"))]
+  ColorCOLRv1,
+  /// Supports the `SVG` table.
+  #[cfg_attr(feature = "serde", serde(rename = "color-svg"))]
+  ColorSVG,
+  /// Supports the `sbix` table.
+  #[cfg_attr(feature = "serde", serde(rename = "color-sbix"))]
   ColorSbix,
-  /// support ColorCbdt
-  ColorCbdt,
+  /// Supports the `CBDT` table.
+  #[cfg_attr(feature = "serde", serde(rename = "color-cbdt"))]
+  ColorCBDT,
 
-  /// support Variations
+  /// Supports Variations
+  /// The variations tech refers to the support of font variations
+  #[cfg_attr(feature = "serde", serde(rename = "variations"))] 
   Variations,
-  /// support Palettes
+  /// Supports Palettes
+  /// The palettes tech refers to support for font palettes
+  #[cfg_attr(feature = "serde", serde(rename = "palettes"))] 
   Palettes,
-  /// support Incremental
+  /// Supports Incremental
+  /// The incremental tech refers to client support for incremental font loading, using either the range-request or the patch-subset method
+  #[cfg_attr(feature = "serde", serde(rename = "incremental"))] 
   Incremental,
 }
 
@@ -304,11 +322,11 @@ impl<'i> Parse<'i> for FontTechnology {
           "features-opentype" => Ok(FontTechnology::FeaturesOpentype),
           "features-aat" => Ok(FontTechnology::FeaturesAat),
           "features-graphite" => Ok(FontTechnology::FeaturesGraphite),
-          "color-colrv0" => Ok(FontTechnology::ColorColrv0),
-          "color-colrv1" => Ok(FontTechnology::ColorColrv1),
-          "color-svg" => Ok(FontTechnology::ColorSvg),
+          "color-colrv0" => Ok(FontTechnology::ColorCOLRv0),
+          "color-colrv1" => Ok(FontTechnology::ColorCOLRv1),
+          "color-svg" => Ok(FontTechnology::ColorSVG),
           "color-sbix" => Ok(FontTechnology::ColorSbix),
-          "color-cbdt" => Ok(FontTechnology::ColorCbdt),
+          "color-cbdt" => Ok(FontTechnology::ColorCBDT),
           _ => Err(location.new_unexpected_token_error(
             cssparser::Token::Ident(ident.clone())
           ))
@@ -328,11 +346,11 @@ impl ToCss for FontTechnology {
       FontTechnology::FeaturesOpentype => "features-opentype",
       FontTechnology::FeaturesAat => "features-aat",
       FontTechnology::FeaturesGraphite => "features-graphite",
-      FontTechnology::ColorColrv0 => "color-colrv0",
-      FontTechnology::ColorColrv1 => "color-colrv1",
-      FontTechnology::ColorSvg => "color-svg",
+      FontTechnology::ColorCOLRv0 => "color-colrv0",
+      FontTechnology::ColorCOLRv1 => "color-colrv1",
+      FontTechnology::ColorSVG => "color-svg",
       FontTechnology::ColorSbix => "color-sbix",
-      FontTechnology::ColorCbdt => "color-cbdt",
+      FontTechnology::ColorCBDT => "color-cbdt",
       FontTechnology::Variations => "variations",
       FontTechnology::Palettes => "palettes",
       FontTechnology::Incremental => "incremental",


### PR DESCRIPTION
Closes: #254 


https://github.com/parcel-bundler/parcel-css/blob/5a6801ce26f9ae9d07d44d3427de4a6b48663261/src/lib.rs#L9425-L9430
should we have this test, if we should, please tell me how to make it pass correctly, thanks

I tried to propagate the error up
https://github.com/parcel-bundler/parcel-css/blob/5a6801ce26f9ae9d07d44d3427de4a6b48663261/src/rules/font_face.rs#L70-L85

But here the error have been ignored again
https://github.com/parcel-bundler/parcel-css/blob/5a6801ce26f9ae9d07d44d3427de4a6b48663261/src/rules/font_face.rs#L430-L435
