### PR TITLE
C bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "cbindgen"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6358dedf60f4d9b8db43ad187391afe959746101346fe51bb978126bec61dfb"
+dependencies = [
+ "clap",
+ "heck",
+ "indexmap",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+ "tempfile",
+ "toml",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,16 +202,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.14"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
+checksum = "8e538f9ee5aa3b3963f09a997035f883677966ed50fce0292611927ce6f6d8c6"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
  "lazy_static",
- "os_str_bytes",
  "strsim",
  "termcolor",
  "textwrap",
@@ -200,15 +219,24 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.14"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
+checksum = "a7f98063cac4652f23ccda556b8d04347a7fc4b2cff1f7577cc8c6546e0d8078"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -795,9 +823,6 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "parcel_css"
@@ -824,6 +849,15 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+]
+
+[[package]]
+name = "parcel_css_c_bindings"
+version = "0.1.0"
+dependencies = [
+ "cbindgen",
+ "parcel_css",
+ "parcel_sourcemap",
 ]
 
 [[package]]
@@ -1064,11 +1098,11 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1394,13 +1428,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1434,9 +1468,9 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -1478,10 +1512,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "toml"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "unindent"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,6 +855,7 @@ dependencies = [
 name = "parcel_css_c_bindings"
 version = "0.1.0"
 dependencies = [
+ "browserslist-rs",
  "cbindgen",
  "parcel_css",
  "parcel_sourcemap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
 members = [
   "node",
-  "selectors"
+  "selectors",
+  "c"
 ]
 
 [package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ serde_json = "1"
 
 [features]
 default = ["grid"]
+browserslist = ["browserslist-rs"]
 cli = ["clap", "serde_json", "pathdiff", "browserslist-rs", "jemallocator"]
 grid = []
 serde = ["smallvec/serde", "cssparser/serde"]

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -9,8 +9,9 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-parcel_css = { path = "../" }
+parcel_css = { path = "../", features = ["browserslist"] }
 parcel_sourcemap = { version = "2.1.0", features = ["json"] }
+browserslist-rs = { version = "0.7.0" }
 
 [build-dependencies]
 cbindgen = "0.24.3"

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+authors = ["Devon Govett <devongovett@gmail.com>"]
+name = "parcel_css_c_bindings"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+parcel_css = { path = "../" }
+parcel_sourcemap = { version = "2.1.0", features = ["json"] }
+
+[build-dependencies]
+cbindgen = "0.24.3"

--- a/c/build.rs
+++ b/c/build.rs
@@ -1,0 +1,11 @@
+extern crate cbindgen;
+
+use std::env;
+
+fn main() {
+  let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+
+  cbindgen::generate(crate_dir)
+    .expect("Unable to generate bindings")
+    .write_to_file("parcel_css.h");
+}

--- a/c/cbindgen.toml
+++ b/c/cbindgen.toml
@@ -1,0 +1,5 @@
+language = "C"
+
+[parse]
+parse_deps = true
+include = ["parcel_css"]

--- a/c/cbindgen.toml
+++ b/c/cbindgen.toml
@@ -6,3 +6,6 @@ include = ["parcel_css"]
 
 [export.rename]
 StyleSheetWrapper = "StyleSheet"
+
+[enum]
+prefix_with_name = true

--- a/c/cbindgen.toml
+++ b/c/cbindgen.toml
@@ -3,3 +3,6 @@ language = "C"
 [parse]
 parse_deps = true
 include = ["parcel_css"]
+
+[export.rename]
+StyleSheetWrapper = "StyleSheet"

--- a/c/parcel_css.h
+++ b/c/parcel_css.h
@@ -3,6 +3,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+typedef struct CssError CssError;
+
 /**
  * A CSS style sheet, representing a `.css` file or inline `<style>` element.
  *
@@ -44,13 +46,18 @@ typedef struct StyleSheet StyleSheet;
 typedef struct RawString {
   char *text;
   uintptr_t len;
-  uintptr_t cap;
 } RawString;
 
-struct StyleSheet *stylesheet_parse(const char *source, uintptr_t len);
+struct StyleSheet *stylesheet_parse(const char *source, uintptr_t len, struct CssError **error);
 
-struct RawString stylesheet_to_css(struct StyleSheet *stylesheet);
+bool stylesheet_transform(struct StyleSheet *stylesheet, struct CssError **error);
+
+struct RawString stylesheet_to_css(struct StyleSheet *stylesheet, struct CssError **error);
 
 void stylesheet_free(struct StyleSheet *stylesheet);
 
 void raw_string_free(struct RawString s);
+
+struct RawString error_message(struct CssError *error);
+
+void error_free(struct CssError *error);

--- a/c/parcel_css.h
+++ b/c/parcel_css.h
@@ -129,25 +129,27 @@ typedef struct ToCssOptions {
   struct PseudoClasses pseudo_classes;
 } ToCssOptions;
 
-bool browserslist_to_targets(const char *query, struct Targets *targets, struct CssError **error);
+bool parcel_css_browserslist_to_targets(const char *query,
+                                        struct Targets *targets,
+                                        struct CssError **error);
 
-struct StyleSheet *stylesheet_parse(const char *source,
-                                    uintptr_t len,
-                                    struct ParseOptions options,
-                                    struct CssError **error);
+struct StyleSheet *parcel_css_stylesheet_parse(const char *source,
+                                               uintptr_t len,
+                                               struct ParseOptions options,
+                                               struct CssError **error);
 
-bool stylesheet_transform(struct StyleSheet *stylesheet,
-                          struct TransformOptions options,
-                          struct CssError **error);
-
-struct ToCssResult stylesheet_to_css(struct StyleSheet *stylesheet,
-                                     struct ToCssOptions options,
+bool parcel_css_stylesheet_transform(struct StyleSheet *stylesheet,
+                                     struct TransformOptions options,
                                      struct CssError **error);
 
-void stylesheet_free(struct StyleSheet *stylesheet);
+struct ToCssResult parcel_css_stylesheet_to_css(struct StyleSheet *stylesheet,
+                                                struct ToCssOptions options,
+                                                struct CssError **error);
 
-void to_css_result_free(struct ToCssResult result);
+void parcel_css_stylesheet_free(struct StyleSheet *stylesheet);
 
-const char *error_message(struct CssError *error);
+void parcel_css_to_css_result_free(struct ToCssResult result);
 
-void error_free(struct CssError *error);
+const char *parcel_css_error_message(struct CssError *error);
+
+void parcel_css_error_free(struct CssError *error);

--- a/c/parcel_css.h
+++ b/c/parcel_css.h
@@ -1,0 +1,56 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/**
+ * A CSS style sheet, representing a `.css` file or inline `<style>` element.
+ *
+ * Style sheets can be parsed from a string, constructed from scratch,
+ * or created using a [Bundler](super::bundler::Bundler). Then, they can be
+ * minified and transformed for a set of target browsers, and serialied to a string.
+ *
+ * # Example
+ *
+ * ```
+ * use parcel_css::stylesheet::{
+ *   StyleSheet, ParserOptions, MinifyOptions, PrinterOptions
+ * };
+ *
+ * // Parse a style sheet from a string.
+ * let mut stylesheet = StyleSheet::parse(
+ *   r#"
+ *   .foo {
+ *     color: red;
+ *   }
+ *
+ *   .bar {
+ *     color: red;
+ *   }
+ *   "#,
+ *   ParserOptions::default()
+ * ).unwrap();
+ *
+ * // Minify the stylesheet.
+ * stylesheet.minify(MinifyOptions::default()).unwrap();
+ *
+ * // Serialize it to a string.
+ * let res = stylesheet.to_css(PrinterOptions::default()).unwrap();
+ * assert_eq!(res.code, ".foo, .bar {\n  color: red;\n}\n");
+ * ```
+ */
+typedef struct StyleSheet StyleSheet;
+
+typedef struct RawString {
+  char *text;
+  uintptr_t len;
+  uintptr_t cap;
+} RawString;
+
+struct StyleSheet *stylesheet_parse(const char *source, uintptr_t len);
+
+struct RawString stylesheet_to_css(struct StyleSheet *stylesheet);
+
+void stylesheet_free(struct StyleSheet *stylesheet);
+
+void raw_string_free(struct RawString s);

--- a/c/parcel_css.h
+++ b/c/parcel_css.h
@@ -153,3 +153,7 @@ void parcel_css_to_css_result_free(struct ToCssResult result);
 const char *parcel_css_error_message(struct CssError *error);
 
 void parcel_css_error_free(struct CssError *error);
+
+uintptr_t parcel_css_stylesheet_get_warning_count(struct StyleSheet *stylesheet);
+
+const char *parcel_css_stylesheet_get_warning(struct StyleSheet *stylesheet, uintptr_t index);

--- a/c/parcel_css.h
+++ b/c/parcel_css.h
@@ -40,9 +40,75 @@ typedef struct RawString {
   uintptr_t len;
 } RawString;
 
+typedef enum CssModuleReference_Tag {
+  /**
+   * A local reference.
+   */
+  CssModuleReference_Local,
+  /**
+   * A global reference.
+   */
+  CssModuleReference_Global,
+  /**
+   * A reference to an export in a different file.
+   */
+  CssModuleReference_Dependency,
+} CssModuleReference_Tag;
+
+typedef struct CssModuleReference_Local_Body {
+  /**
+   * The local (compiled) name for the reference.
+   */
+  struct RawString name;
+} CssModuleReference_Local_Body;
+
+typedef struct CssModuleReference_Global_Body {
+  /**
+   * The referenced global name.
+   */
+  struct RawString name;
+} CssModuleReference_Global_Body;
+
+typedef struct CssModuleReference_Dependency_Body {
+  /**
+   * The name to reference within the dependency.
+   */
+  struct RawString name;
+  /**
+   * The dependency specifier for the referenced file.
+   */
+  struct RawString specifier;
+} CssModuleReference_Dependency_Body;
+
+typedef struct CssModuleReference {
+  CssModuleReference_Tag tag;
+  union {
+    CssModuleReference_Local_Body local;
+    CssModuleReference_Global_Body global;
+    CssModuleReference_Dependency_Body dependency;
+  };
+} CssModuleReference;
+
+typedef struct CssModuleExport {
+  struct RawString exported;
+  struct RawString local;
+  bool is_referenced;
+  struct CssModuleReference *composes;
+  uintptr_t composes_len;
+} CssModuleExport;
+
+typedef struct CssModulePlaceholder {
+  struct RawString placeholder;
+  struct CssModuleReference reference;
+} CssModulePlaceholder;
+
 typedef struct ToCssResult {
   struct RawString code;
   struct RawString map;
+  struct CssModuleExport *exports;
+  uintptr_t exports_len;
+  struct CssModulePlaceholder *references;
+  uintptr_t references_len;
 } ToCssResult;
 
 typedef struct PseudoClasses {

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -132,7 +132,7 @@ macro_rules! unwrap {
 }
 
 #[no_mangle]
-pub extern "C" fn browserslist_to_targets(
+pub extern "C" fn parcel_css_browserslist_to_targets(
   query: *const c_char,
   targets: *mut Targets,
   error: *mut *mut CssError,
@@ -243,7 +243,7 @@ impl<'a> Into<parcel_css::printer::PseudoClasses<'a>> for PseudoClasses {
 }
 
 #[no_mangle]
-pub extern "C" fn stylesheet_parse(
+pub extern "C" fn parcel_css_stylesheet_parse(
   source: *const c_char,
   len: usize,
   options: ParseOptions,
@@ -291,7 +291,7 @@ pub extern "C" fn stylesheet_parse(
 }
 
 #[no_mangle]
-pub extern "C" fn stylesheet_transform(
+pub extern "C" fn parcel_css_stylesheet_transform(
   stylesheet: *mut StyleSheetWrapper,
   options: TransformOptions,
   error: *mut *mut CssError,
@@ -302,7 +302,7 @@ pub extern "C" fn stylesheet_transform(
 }
 
 #[no_mangle]
-pub extern "C" fn stylesheet_to_css(
+pub extern "C" fn parcel_css_stylesheet_to_css(
   stylesheet: *mut StyleSheetWrapper,
   options: ToCssOptions,
   error: *mut *mut CssError,
@@ -405,7 +405,7 @@ pub extern "C" fn stylesheet_to_css(
 }
 
 #[no_mangle]
-pub extern "C" fn stylesheet_free(stylesheet: *mut StyleSheetWrapper) {
+pub extern "C" fn parcel_css_stylesheet_free(stylesheet: *mut StyleSheetWrapper) {
   if !stylesheet.is_null() {
     drop(unsafe { Box::from_raw(stylesheet) })
   }
@@ -451,7 +451,7 @@ impl Drop for ToCssResult {
 }
 
 #[no_mangle]
-pub extern "C" fn to_css_result_free(result: ToCssResult) {
+pub extern "C" fn parcel_css_to_css_result_free(result: ToCssResult) {
   drop(result)
 }
 
@@ -550,7 +550,7 @@ impl Drop for RawString {
 }
 
 #[no_mangle]
-pub extern "C" fn error_message(error: *mut CssError) -> *const c_char {
+pub extern "C" fn parcel_css_error_message(error: *mut CssError) -> *const c_char {
   match unsafe { error.as_mut() } {
     Some(err) => err.message(),
     None => std::ptr::null(),
@@ -558,7 +558,7 @@ pub extern "C" fn error_message(error: *mut CssError) -> *const c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn error_free(error: *mut CssError) {
+pub extern "C" fn parcel_css_error_free(error: *mut CssError) {
   if !error.is_null() {
     drop(unsafe { Box::from_raw(error) })
   }

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -1,26 +1,58 @@
-use std::mem::ManuallyDrop;
 use std::os::raw::c_char;
 
-use parcel_css::stylesheet::{ParserOptions, PrinterOptions, StyleSheet};
+use parcel_css::error::{Error, MinifyErrorKind, ParserError, PrinterError};
+use parcel_css::stylesheet::{MinifyOptions, ParserOptions, PrinterOptions, StyleSheet};
 
-#[no_mangle]
-pub extern "C" fn stylesheet_parse<'i, 'o>(source: *const c_char, len: usize) -> *mut StyleSheet<'i, 'o> {
-  let slice = unsafe { std::slice::from_raw_parts(source as *const u8, len) };
-  let code = unsafe { std::str::from_utf8_unchecked(slice) };
-  // TODO: error handling
-  Box::into_raw(Box::new(StyleSheet::parse(code, ParserOptions::default()).unwrap()))
+pub enum CssError<'i> {
+  ParserError(Error<ParserError<'i>>),
+  MinifyError(Error<MinifyErrorKind>),
+  PrinterError(PrinterError),
 }
 
 #[no_mangle]
-pub extern "C" fn stylesheet_to_css(stylesheet: *mut StyleSheet) -> RawString {
+pub extern "C" fn stylesheet_parse(
+  source: *const c_char,
+  len: usize,
+  error: *mut *mut CssError,
+) -> *mut StyleSheet {
+  let slice = unsafe { std::slice::from_raw_parts(source as *const u8, len) };
+  let code = unsafe { std::str::from_utf8_unchecked(slice) };
+  match StyleSheet::parse(code, ParserOptions::default()) {
+    Ok(stylesheet) => Box::into_raw(Box::new(stylesheet)),
+    Err(err) => unsafe {
+      *error = Box::into_raw(Box::new(CssError::ParserError(err)));
+      std::ptr::null_mut()
+    },
+  }
+}
+
+#[no_mangle]
+pub extern "C" fn stylesheet_transform(stylesheet: *mut StyleSheet, error: *mut *mut CssError) -> bool {
   let stylesheet = unsafe { stylesheet.as_mut() }.unwrap();
-  let res = stylesheet
-    .to_css(PrinterOptions {
-      minify: true,
-      ..PrinterOptions::default()
-    })
-    .unwrap(); // TODO: error handling
-  res.code.into()
+  match stylesheet.minify(MinifyOptions::default()) {
+    Ok(_) => true,
+    Err(err) => unsafe {
+      *error = Box::into_raw(Box::new(CssError::MinifyError(err)));
+      false
+    },
+  }
+}
+
+#[no_mangle]
+pub extern "C" fn stylesheet_to_css(stylesheet: *mut StyleSheet, error: *mut *mut CssError) -> RawString {
+  let stylesheet = unsafe { stylesheet.as_mut() }.unwrap();
+  let opts = PrinterOptions {
+    minify: true,
+    ..PrinterOptions::default()
+  };
+
+  match stylesheet.to_css(opts) {
+    Ok(res) => res.code.into(),
+    Err(err) => unsafe {
+      *error = Box::into_raw(Box::new(CssError::PrinterError(err)));
+      RawString::new()
+    },
+  }
 }
 
 #[no_mangle]
@@ -34,17 +66,22 @@ pub extern "C" fn stylesheet_free(stylesheet: *mut StyleSheet) {
 pub struct RawString {
   text: *mut c_char,
   len: usize,
-  cap: usize,
+}
+
+impl RawString {
+  fn new() -> Self {
+    RawString {
+      text: std::ptr::null_mut(),
+      len: 0,
+    }
+  }
 }
 
 impl From<String> for RawString {
   fn from(string: String) -> RawString {
-    let mut string = ManuallyDrop::new(string);
-    let ptr = string.as_mut_ptr();
     RawString {
-      text: ptr as *mut c_char,
       len: string.len(),
-      cap: string.capacity(),
+      text: Box::into_raw(string.into_boxed_str()) as *mut c_char,
     }
   }
 }
@@ -54,13 +91,31 @@ impl Drop for RawString {
     if self.text.is_null() {
       return;
     }
-    let s = unsafe { String::from_raw_parts(self.text as *mut u8, self.len, self.cap) };
+    drop(unsafe { Box::from_raw(self.text) });
     self.text = std::ptr::null_mut();
-    drop(s)
   }
 }
 
 #[no_mangle]
 pub extern "C" fn raw_string_free(s: RawString) {
   drop(s)
+}
+
+#[no_mangle]
+pub extern "C" fn error_message(error: *mut CssError) -> RawString {
+  match unsafe { error.as_ref() } {
+    Some(err) => match err {
+      CssError::ParserError(err) => err.to_string().into(),
+      CssError::MinifyError(err) => err.to_string().into(),
+      CssError::PrinterError(err) => err.to_string().into(),
+    },
+    None => String::new().into(),
+  }
+}
+
+#[no_mangle]
+pub extern "C" fn error_free(error: *mut CssError) {
+  if !error.is_null() {
+    drop(unsafe { Box::from_raw(error) })
+  }
 }

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -1,65 +1,380 @@
+use std::collections::HashSet;
+use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 
+use parcel_css::css_modules::PatternParseError;
 use parcel_css::error::{Error, MinifyErrorKind, ParserError, PrinterError};
 use parcel_css::stylesheet::{MinifyOptions, ParserOptions, PrinterOptions, StyleSheet};
+use parcel_css::targets::Browsers;
+use parcel_sourcemap::SourceMap;
 
-pub enum CssError<'i> {
+pub struct StyleSheetWrapper<'i, 'o> {
+  stylesheet: StyleSheet<'i, 'o>,
+  source: &'i str,
+}
+
+pub struct CssError<'i> {
+  kind: ErrorKind<'i>,
+  message: Option<CString>,
+}
+
+impl<'i> CssError<'i> {
+  fn message(&mut self) -> *const c_char {
+    if let Some(message) = &self.message {
+      return message.as_ptr();
+    }
+
+    let string: String = match &self.kind {
+      ErrorKind::ParserError(err) => err.to_string().into(),
+      ErrorKind::MinifyError(err) => err.to_string().into(),
+      ErrorKind::PrinterError(err) => err.to_string().into(),
+      ErrorKind::PatternParseError(err) => err.to_string().into(),
+      ErrorKind::BrowserslistError(err) => err.to_string().into(),
+      ErrorKind::SourceMapError(err) => err.to_string().into(),
+    };
+
+    self.message = Some(CString::new(string).unwrap());
+    self.message.as_ref().unwrap().as_ptr()
+  }
+}
+
+pub enum ErrorKind<'i> {
   ParserError(Error<ParserError<'i>>),
   MinifyError(Error<MinifyErrorKind>),
   PrinterError(PrinterError),
+  PatternParseError(PatternParseError),
+  BrowserslistError(browserslist::Error),
+  SourceMapError(parcel_sourcemap::SourceMapError),
+}
+
+macro_rules! impl_from {
+  ($name: ident, $t: ty) => {
+    impl<'i> From<$t> for CssError<'i> {
+      fn from(err: $t) -> Self {
+        CssError {
+          kind: ErrorKind::$name(err),
+          message: None,
+        }
+      }
+    }
+  };
+}
+
+impl_from!(ParserError, Error<ParserError<'i>>);
+impl_from!(MinifyError, Error<MinifyErrorKind>);
+impl_from!(PrinterError, PrinterError);
+impl_from!(PatternParseError, PatternParseError);
+impl_from!(BrowserslistError, browserslist::Error);
+impl_from!(SourceMapError, parcel_sourcemap::SourceMapError);
+
+#[repr(C)]
+pub struct ParseOptions {
+  filename: *const c_char,
+  nesting: bool,
+  custom_media: bool,
+  css_modules: bool,
+  css_modules_pattern: *const c_char,
+  css_modules_dashed_idents: bool,
+  error_recovery: bool,
+}
+
+#[repr(C)]
+#[derive(Default, PartialEq)]
+pub struct Targets {
+  android: u32,
+  chrome: u32,
+  edge: u32,
+  firefox: u32,
+  ie: u32,
+  ios_saf: u32,
+  opera: u32,
+  safari: u32,
+  samsung: u32,
+}
+
+impl Into<Browsers> for Targets {
+  fn into(self) -> Browsers {
+    macro_rules! browser {
+      ($val: expr) => {
+        if $val > 0 {
+          Some($val)
+        } else {
+          None
+        }
+      };
+    }
+
+    Browsers {
+      android: browser!(self.android),
+      chrome: browser!(self.chrome),
+      edge: browser!(self.edge),
+      firefox: browser!(self.firefox),
+      ie: browser!(self.ie),
+      ios_saf: browser!(self.ios_saf),
+      opera: browser!(self.opera),
+      safari: browser!(self.safari),
+      samsung: browser!(self.samsung),
+    }
+  }
+}
+
+macro_rules! unwrap {
+  ($result: expr, $error: ident, $ret: expr) => {
+    match $result {
+      Ok(v) => v,
+      Err(err) => unsafe {
+        *$error = Box::into_raw(Box::new(err.into()));
+        return $ret;
+      },
+    }
+  };
+}
+
+#[no_mangle]
+pub extern "C" fn browserslist_to_targets(
+  query: *const c_char,
+  targets: *mut Targets,
+  error: *mut *mut CssError,
+) -> bool {
+  let string = unsafe { std::str::from_utf8_unchecked(CStr::from_ptr(query).to_bytes()) };
+  match Browsers::from_browserslist([string]) {
+    Ok(Some(browsers)) => {
+      let targets = unsafe { &mut *targets };
+      targets.android = browsers.android.unwrap_or_default();
+      targets.chrome = browsers.chrome.unwrap_or_default();
+      targets.edge = browsers.edge.unwrap_or_default();
+      targets.firefox = browsers.firefox.unwrap_or_default();
+      targets.ie = browsers.ie.unwrap_or_default();
+      targets.ios_saf = browsers.ios_saf.unwrap_or_default();
+      targets.opera = browsers.opera.unwrap_or_default();
+      targets.safari = browsers.safari.unwrap_or_default();
+      targets.samsung = browsers.samsung.unwrap_or_default();
+      true
+    }
+    Ok(None) => true,
+    Err(err) => unsafe {
+      *error = Box::into_raw(Box::new(err.into()));
+      false
+    },
+  }
+}
+
+#[repr(C)]
+pub struct TransformOptions {
+  targets: Targets,
+  unused_symbols: *mut *mut c_char,
+  unused_symbols_len: usize,
+}
+
+impl Into<MinifyOptions> for TransformOptions {
+  fn into(self) -> MinifyOptions {
+    let mut unused_symbols = HashSet::new();
+    let slice = unsafe { std::slice::from_raw_parts(self.unused_symbols, self.unused_symbols_len) };
+    for symbol in slice {
+      let string = unsafe { std::str::from_utf8_unchecked(CStr::from_ptr(*symbol).to_bytes()).to_owned() };
+      unused_symbols.insert(string);
+    }
+
+    MinifyOptions {
+      targets: if self.targets != Targets::default() {
+        Some(self.targets.into())
+      } else {
+        None
+      },
+      unused_symbols,
+    }
+  }
+}
+
+#[repr(C)]
+pub struct ToCssOptions {
+  minify: bool,
+  source_map: bool,
+  input_source_map: *const c_char,
+  input_source_map_len: usize,
+  targets: Targets,
+  analyze_dependencies: bool,
+  pseudo_classes: PseudoClasses,
+}
+
+#[derive(PartialEq)]
+#[repr(C)]
+pub struct PseudoClasses {
+  hover: *const c_char,
+  active: *const c_char,
+  focus: *const c_char,
+  focus_visible: *const c_char,
+  focus_within: *const c_char,
+}
+
+impl Default for PseudoClasses {
+  fn default() -> Self {
+    PseudoClasses {
+      hover: std::ptr::null(),
+      active: std::ptr::null(),
+      focus: std::ptr::null(),
+      focus_visible: std::ptr::null(),
+      focus_within: std::ptr::null(),
+    }
+  }
+}
+
+impl<'a> Into<parcel_css::printer::PseudoClasses<'a>> for PseudoClasses {
+  fn into(self) -> parcel_css::printer::PseudoClasses<'a> {
+    macro_rules! pc {
+      ($ptr: expr) => {
+        if $ptr.is_null() {
+          None
+        } else {
+          Some(unsafe { std::str::from_utf8_unchecked(CStr::from_ptr($ptr).to_bytes()) })
+        }
+      };
+    }
+
+    parcel_css::printer::PseudoClasses {
+      hover: pc!(self.hover),
+      active: pc!(self.active),
+      focus: pc!(self.focus),
+      focus_visible: pc!(self.focus_visible),
+      focus_within: pc!(self.focus_within),
+    }
+  }
 }
 
 #[no_mangle]
 pub extern "C" fn stylesheet_parse(
   source: *const c_char,
   len: usize,
+  options: ParseOptions,
   error: *mut *mut CssError,
-) -> *mut StyleSheet {
+) -> *mut StyleSheetWrapper {
   let slice = unsafe { std::slice::from_raw_parts(source as *const u8, len) };
   let code = unsafe { std::str::from_utf8_unchecked(slice) };
-  match StyleSheet::parse(code, ParserOptions::default()) {
-    Ok(stylesheet) => Box::into_raw(Box::new(stylesheet)),
-    Err(err) => unsafe {
-      *error = Box::into_raw(Box::new(CssError::ParserError(err)));
-      std::ptr::null_mut()
+  let opts = ParserOptions {
+    filename: if options.filename.is_null() {
+      String::new()
+    } else {
+      unsafe { std::str::from_utf8_unchecked(CStr::from_ptr(options.filename).to_bytes()).to_owned() }
     },
-  }
-}
-
-#[no_mangle]
-pub extern "C" fn stylesheet_transform(stylesheet: *mut StyleSheet, error: *mut *mut CssError) -> bool {
-  let stylesheet = unsafe { stylesheet.as_mut() }.unwrap();
-  match stylesheet.minify(MinifyOptions::default()) {
-    Ok(_) => true,
-    Err(err) => unsafe {
-      *error = Box::into_raw(Box::new(CssError::MinifyError(err)));
-      false
+    nesting: options.nesting,
+    custom_media: options.custom_media,
+    css_modules: if options.css_modules {
+      let pattern = if !options.css_modules_pattern.is_null() {
+        let pattern =
+          unsafe { std::str::from_utf8_unchecked(CStr::from_ptr(options.css_modules_pattern).to_bytes()) };
+        unwrap!(
+          parcel_css::css_modules::Pattern::parse(pattern),
+          error,
+          std::ptr::null_mut()
+        )
+      } else {
+        parcel_css::css_modules::Pattern::default()
+      };
+      Some(parcel_css::css_modules::Config {
+        pattern,
+        dashed_idents: options.css_modules_dashed_idents,
+      })
+    } else {
+      None
     },
-  }
-}
-
-#[no_mangle]
-pub extern "C" fn stylesheet_to_css(stylesheet: *mut StyleSheet, error: *mut *mut CssError) -> RawString {
-  let stylesheet = unsafe { stylesheet.as_mut() }.unwrap();
-  let opts = PrinterOptions {
-    minify: true,
-    ..PrinterOptions::default()
+    error_recovery: options.error_recovery,
+    source_index: 0,
+    warnings: None,
   };
 
-  match stylesheet.to_css(opts) {
-    Ok(res) => res.code.into(),
-    Err(err) => unsafe {
-      *error = Box::into_raw(Box::new(CssError::PrinterError(err)));
-      RawString::new()
+  let stylesheet = unwrap!(StyleSheet::parse(code, opts), error, std::ptr::null_mut());
+  Box::into_raw(Box::new(StyleSheetWrapper {
+    stylesheet,
+    source: code,
+  }))
+}
+
+#[no_mangle]
+pub extern "C" fn stylesheet_transform(
+  stylesheet: *mut StyleSheetWrapper,
+  options: TransformOptions,
+  error: *mut *mut CssError,
+) -> bool {
+  let wrapper = unsafe { stylesheet.as_mut() }.unwrap();
+  unwrap!(wrapper.stylesheet.minify(options.into()), error, false);
+  true
+}
+
+#[no_mangle]
+pub extern "C" fn stylesheet_to_css(
+  stylesheet: *mut StyleSheetWrapper,
+  options: ToCssOptions,
+  error: *mut *mut CssError,
+) -> ToCssResult {
+  let wrapper = unsafe { stylesheet.as_mut() }.unwrap();
+  let mut source_map = if options.source_map {
+    let mut sm = SourceMap::new("/");
+    sm.add_source(&wrapper.stylesheet.sources[0]);
+    unwrap!(sm.set_source_content(0, wrapper.source), error, ToCssResult::default());
+    Some(sm)
+  } else {
+    None
+  };
+
+  let opts = PrinterOptions {
+    minify: options.minify,
+    source_map: source_map.as_mut(),
+    targets: if options.targets != Targets::default() {
+      Some(options.targets.into())
+    } else {
+      None
     },
+    analyze_dependencies: options.analyze_dependencies,
+    pseudo_classes: if options.pseudo_classes != PseudoClasses::default() {
+      Some(options.pseudo_classes.into())
+    } else {
+      None
+    },
+  };
+
+  let res = unwrap!(wrapper.stylesheet.to_css(opts), error, ToCssResult::default());
+
+  let map = if let Some(mut source_map) = source_map {
+    if !options.input_source_map.is_null() {
+      let slice =
+        unsafe { std::slice::from_raw_parts(options.input_source_map as *const u8, options.input_source_map_len) };
+      let input_source_map = unsafe { std::str::from_utf8_unchecked(slice) };
+      let mut sm = unwrap!(
+        SourceMap::from_json("/", input_source_map),
+        error,
+        ToCssResult::default()
+      );
+      unwrap!(source_map.extends(&mut sm), error, ToCssResult::default());
+    }
+
+    unwrap!(source_map.to_json(None), error, ToCssResult::default()).into()
+  } else {
+    RawString::default()
+  };
+
+  ToCssResult {
+    code: res.code.into(),
+    map,
   }
 }
 
 #[no_mangle]
-pub extern "C" fn stylesheet_free(stylesheet: *mut StyleSheet) {
+pub extern "C" fn stylesheet_free(stylesheet: *mut StyleSheetWrapper) {
   if !stylesheet.is_null() {
     drop(unsafe { Box::from_raw(stylesheet) })
   }
+}
+
+#[derive(Default)]
+#[repr(C)]
+pub struct ToCssResult {
+  code: RawString,
+  map: RawString,
+}
+
+#[no_mangle]
+pub extern "C" fn to_css_result_free(result: ToCssResult) {
+  drop(result)
 }
 
 #[repr(C)]
@@ -68,8 +383,8 @@ pub struct RawString {
   len: usize,
 }
 
-impl RawString {
-  fn new() -> Self {
+impl Default for RawString {
+  fn default() -> Self {
     RawString {
       text: std::ptr::null_mut(),
       len: 0,
@@ -97,19 +412,10 @@ impl Drop for RawString {
 }
 
 #[no_mangle]
-pub extern "C" fn raw_string_free(s: RawString) {
-  drop(s)
-}
-
-#[no_mangle]
-pub extern "C" fn error_message(error: *mut CssError) -> RawString {
-  match unsafe { error.as_ref() } {
-    Some(err) => match err {
-      CssError::ParserError(err) => err.to_string().into(),
-      CssError::MinifyError(err) => err.to_string().into(),
-      CssError::PrinterError(err) => err.to_string().into(),
-    },
-    None => String::new().into(),
+pub extern "C" fn error_message(error: *mut CssError) -> *const c_char {
+  match unsafe { error.as_mut() } {
+    Some(err) => err.message(),
+    None => std::ptr::null(),
   }
 }
 

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -1,0 +1,66 @@
+use std::mem::ManuallyDrop;
+use std::os::raw::c_char;
+
+use parcel_css::stylesheet::{ParserOptions, PrinterOptions, StyleSheet};
+
+#[no_mangle]
+pub extern "C" fn stylesheet_parse<'i, 'o>(source: *const c_char, len: usize) -> *mut StyleSheet<'i, 'o> {
+  let slice = unsafe { std::slice::from_raw_parts(source as *const u8, len) };
+  let code = unsafe { std::str::from_utf8_unchecked(slice) };
+  // TODO: error handling
+  Box::into_raw(Box::new(StyleSheet::parse(code, ParserOptions::default()).unwrap()))
+}
+
+#[no_mangle]
+pub extern "C" fn stylesheet_to_css(stylesheet: *mut StyleSheet) -> RawString {
+  let stylesheet = unsafe { stylesheet.as_mut() }.unwrap();
+  let res = stylesheet
+    .to_css(PrinterOptions {
+      minify: true,
+      ..PrinterOptions::default()
+    })
+    .unwrap(); // TODO: error handling
+  res.code.into()
+}
+
+#[no_mangle]
+pub extern "C" fn stylesheet_free(stylesheet: *mut StyleSheet) {
+  if !stylesheet.is_null() {
+    drop(unsafe { Box::from_raw(stylesheet) })
+  }
+}
+
+#[repr(C)]
+pub struct RawString {
+  text: *mut c_char,
+  len: usize,
+  cap: usize,
+}
+
+impl From<String> for RawString {
+  fn from(string: String) -> RawString {
+    let mut string = ManuallyDrop::new(string);
+    let ptr = string.as_mut_ptr();
+    RawString {
+      text: ptr as *mut c_char,
+      len: string.len(),
+      cap: string.capacity(),
+    }
+  }
+}
+
+impl Drop for RawString {
+  fn drop(&mut self) {
+    if self.text.is_null() {
+      return;
+    }
+    let s = unsafe { String::from_raw_parts(self.text as *mut u8, self.len, self.cap) };
+    self.text = std::ptr::null_mut();
+    drop(s)
+  }
+}
+
+#[no_mangle]
+pub extern "C" fn raw_string_free(s: RawString) {
+  drop(s)
+}

--- a/c/test.c
+++ b/c/test.c
@@ -50,6 +50,12 @@ int main()
   if (error)
     goto cleanup;
 
+  size_t warning_count = parcel_css_stylesheet_get_warning_count(stylesheet);
+  for (size_t i = 0; i < warning_count; i++)
+  {
+    printf("warning: %s\n", parcel_css_stylesheet_get_warning(stylesheet, i));
+  }
+
   fwrite(result.code.text, sizeof(char), result.code.len, stdout);
   printf("\n");
   fwrite(result.map.text, sizeof(char), result.map.len, stdout);

--- a/c/test.c
+++ b/c/test.c
@@ -12,31 +12,33 @@ int main()
       "}"
       ".bar {"
       "  color: yellow;"
+      "  composes: foo from './bar.css';"
       "}"
       ".baz:hover {"
-      "  color: red;"
+      "  color: var(--foo from './baz.css');"
       "}";
 
   ParseOptions parse_opts = {
       .filename = "test.css",
       .css_modules = true,
-      .css_modules_pattern = "yo_[name]_[local]"};
+      .css_modules_pattern = "yo_[name]_[local]",
+      .css_modules_dashed_idents = true};
 
   CssError *error = NULL;
   StyleSheet *stylesheet = stylesheet_parse(source, strlen(source), parse_opts, &error);
   if (!stylesheet)
-    return print_error(error);
+    goto cleanup;
 
   char *unused_symbols[1] = {"bar"};
   TransformOptions transform_opts = {
       .unused_symbols = unused_symbols,
-      .unused_symbols_len = 1};
+      .unused_symbols_len = 0};
 
   if (!browserslist_to_targets("last 2 versions, not IE <= 11", &transform_opts.targets, &error))
-    return print_error(error);
+    goto cleanup;
 
   if (!stylesheet_transform(stylesheet, transform_opts, &error))
-    return print_error(error);
+    goto cleanup;
 
   ToCssOptions to_css_opts = {
       .minify = true,
@@ -46,19 +48,47 @@ int main()
 
   ToCssResult result = stylesheet_to_css(stylesheet, to_css_opts, &error);
   if (error)
-    return print_error(error);
+    goto cleanup;
 
-  stylesheet_free(stylesheet);
   fwrite(result.code.text, sizeof(char), result.code.len, stdout);
   printf("\n");
   fwrite(result.map.text, sizeof(char), result.map.len, stdout);
   printf("\n");
-  to_css_result_free(result);
-}
 
-int print_error(CssError *error)
-{
-  printf("error: %s\n", error_message(error));
-  error_free(error);
-  return 1;
+  for (int i = 0; i < result.exports_len; i++)
+  {
+    printf("%.*s -> %.*s\n", (int)result.exports[i].exported.len, result.exports[i].exported.text, (int)result.exports[i].local.len, result.exports[i].local.text);
+    for (int j = 0; j < result.exports[i].composes_len; j++)
+    {
+      const CssModuleReference *ref = &result.exports[i].composes[j];
+      switch (ref->tag)
+      {
+      case CssModuleReference_Local:
+        printf("  composes local: %.*s\n", (int)ref->local.name.len, ref->local.name.text);
+        break;
+      case CssModuleReference_Global:
+        printf("  composes global: %.*s\n", (int)ref->global.name.len, ref->global.name.text);
+        break;
+      case CssModuleReference_Dependency:
+        printf("  composes dependency: %.*s from %.*s\n", (int)ref->dependency.name.len, ref->dependency.name.text, (int)ref->dependency.specifier.len, ref->dependency.specifier.text);
+        break;
+      }
+    }
+  }
+
+  for (int i = 0; i < result.references_len; i++)
+  {
+    printf("placeholder: %.*s\n", (int)result.references[i].placeholder.len, result.references[i].placeholder.text);
+  }
+
+cleanup:
+  stylesheet_free(stylesheet);
+  to_css_result_free(result);
+
+  if (error)
+  {
+    printf("error: %s\n", error_message(error));
+    error_free(error);
+    return 1;
+  }
 }

--- a/c/test.c
+++ b/c/test.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+#include <string.h>
+#include "parcel_css.h"
+
+int main()
+{
+  char *source =
+      ".foo {"
+      "  color: yellow;"
+      "}";
+  StyleSheet *stylesheet = stylesheet_parse(source, strlen(source));
+  RawString result = stylesheet_to_css(stylesheet);
+  stylesheet_free(stylesheet);
+  fwrite(result.text, sizeof(char), result.len, stdout);
+  printf("\n");
+  raw_string_free(result);
+}

--- a/c/test.c
+++ b/c/test.c
@@ -25,7 +25,7 @@ int main()
       .css_modules_dashed_idents = true};
 
   CssError *error = NULL;
-  StyleSheet *stylesheet = stylesheet_parse(source, strlen(source), parse_opts, &error);
+  StyleSheet *stylesheet = parcel_css_stylesheet_parse(source, strlen(source), parse_opts, &error);
   if (!stylesheet)
     goto cleanup;
 
@@ -34,10 +34,10 @@ int main()
       .unused_symbols = unused_symbols,
       .unused_symbols_len = 0};
 
-  if (!browserslist_to_targets("last 2 versions, not IE <= 11", &transform_opts.targets, &error))
+  if (!parcel_css_browserslist_to_targets("last 2 versions, not IE <= 11", &transform_opts.targets, &error))
     goto cleanup;
 
-  if (!stylesheet_transform(stylesheet, transform_opts, &error))
+  if (!parcel_css_stylesheet_transform(stylesheet, transform_opts, &error))
     goto cleanup;
 
   ToCssOptions to_css_opts = {
@@ -46,7 +46,7 @@ int main()
       .pseudo_classes = {
           .hover = "is-hovered"}};
 
-  ToCssResult result = stylesheet_to_css(stylesheet, to_css_opts, &error);
+  ToCssResult result = parcel_css_stylesheet_to_css(stylesheet, to_css_opts, &error);
   if (error)
     goto cleanup;
 
@@ -82,13 +82,13 @@ int main()
   }
 
 cleanup:
-  stylesheet_free(stylesheet);
-  to_css_result_free(result);
+  parcel_css_stylesheet_free(stylesheet);
+  parcel_css_to_css_result_free(result);
 
   if (error)
   {
-    printf("error: %s\n", error_message(error));
-    error_free(error);
+    printf("error: %s\n", parcel_css_error_message(error));
+    parcel_css_error_free(error);
     return 1;
   }
 }

--- a/c/test.c
+++ b/c/test.c
@@ -8,35 +8,57 @@ int main()
 {
   char *source =
       ".foo {"
-      "  color: yellow;"
+      "  color: lch(50.998% 135.363 338);"
       "}"
       ".bar {"
       "  color: yellow;"
+      "}"
+      ".baz:hover {"
+      "  color: red;"
       "}";
 
+  ParseOptions parse_opts = {
+      .filename = "test.css",
+      .css_modules = true,
+      .css_modules_pattern = "yo_[name]_[local]"};
+
   CssError *error = NULL;
-  StyleSheet *stylesheet = stylesheet_parse(source, strlen(source), &error);
+  StyleSheet *stylesheet = stylesheet_parse(source, strlen(source), parse_opts, &error);
   if (!stylesheet)
     return print_error(error);
 
-  if (!stylesheet_transform(stylesheet, &error))
+  char *unused_symbols[1] = {"bar"};
+  TransformOptions transform_opts = {
+      .unused_symbols = unused_symbols,
+      .unused_symbols_len = 1};
+
+  if (!browserslist_to_targets("last 2 versions, not IE <= 11", &transform_opts.targets, &error))
     return print_error(error);
 
-  RawString result = stylesheet_to_css(stylesheet, &error);
+  if (!stylesheet_transform(stylesheet, transform_opts, &error))
+    return print_error(error);
+
+  ToCssOptions to_css_opts = {
+      .minify = true,
+      .source_map = true,
+      .pseudo_classes = {
+          .hover = "is-hovered"}};
+
+  ToCssResult result = stylesheet_to_css(stylesheet, to_css_opts, &error);
   if (error)
     return print_error(error);
 
   stylesheet_free(stylesheet);
-  fwrite(result.text, sizeof(char), result.len, stdout);
+  fwrite(result.code.text, sizeof(char), result.code.len, stdout);
   printf("\n");
-  raw_string_free(result);
+  fwrite(result.map.text, sizeof(char), result.map.len, stdout);
+  printf("\n");
+  to_css_result_free(result);
 }
 
 int print_error(CssError *error)
 {
-  RawString message = error_message(error);
-  printf("error: %.*s\n", (int)message.len, message.text);
-  raw_string_free(message);
+  printf("error: %s\n", error_message(error));
   error_free(error);
   return 1;
 }

--- a/c/test.c
+++ b/c/test.c
@@ -2,16 +2,41 @@
 #include <string.h>
 #include "parcel_css.h"
 
+int print_error(CssError *error);
+
 int main()
 {
   char *source =
       ".foo {"
       "  color: yellow;"
+      "}"
+      ".bar {"
+      "  color: yellow;"
       "}";
-  StyleSheet *stylesheet = stylesheet_parse(source, strlen(source));
-  RawString result = stylesheet_to_css(stylesheet);
+
+  CssError *error = NULL;
+  StyleSheet *stylesheet = stylesheet_parse(source, strlen(source), &error);
+  if (!stylesheet)
+    return print_error(error);
+
+  if (!stylesheet_transform(stylesheet, &error))
+    return print_error(error);
+
+  RawString result = stylesheet_to_css(stylesheet, &error);
+  if (error)
+    return print_error(error);
+
   stylesheet_free(stylesheet);
   fwrite(result.text, sizeof(char), result.len, stdout);
   printf("\n");
   raw_string_free(result);
+}
+
+int print_error(CssError *error)
+{
+  RawString message = error_message(error);
+  printf("error: %.*s\n", (int)message.len, message.text);
+  raw_string_free(message);
+  error_free(error);
+  return 1;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,36 +15,37 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 #[clap(author, about, long_about = None)]
 struct CliArgs {
   /// Target CSS file
+  #[clap(value_parser)]
   input_file: String,
   /// Destination file for the output
-  #[clap(short, long, group = "output_file")]
+  #[clap(short, long, group = "output_file", value_parser)]
   output_file: Option<String>,
   /// Minify the output
-  #[clap(short, long)]
+  #[clap(short, long, value_parser)]
   minify: bool,
   /// Enable parsing CSS nesting
-  #[clap(long)]
+  #[clap(long, value_parser)]
   nesting: bool,
   /// Enable parsing custom media queries
-  #[clap(long)]
+  #[clap(long, value_parser)]
   custom_media: bool,
   /// Enable CSS modules in output.
   /// If no filename is provided, <output_file>.json will be used.
   /// If no --output-file is specified, code and exports will be printed to stdout as JSON.
-  #[clap(long, group = "css_modules")]
+  #[clap(long, group = "css_modules", value_parser)]
   css_modules: Option<Option<String>>,
-  #[clap(long, requires = "css_modules")]
+  #[clap(long, requires = "css_modules", value_parser)]
   css_modules_pattern: Option<String>,
-  #[clap(long, requires = "css_modules")]
+  #[clap(long, requires = "css_modules", value_parser)]
   css_modules_dashed_idents: bool,
   /// Enable sourcemap, at <output_file>.map
-  #[clap(long, requires = "output_file")]
+  #[clap(long, requires = "output_file", value_parser)]
   sourcemap: bool,
-  #[clap(long)]
+  #[clap(long, value_parser)]
   bundle: bool,
-  #[clap(short, long)]
+  #[clap(short, long, value_parser)]
   targets: Vec<String>,
-  #[clap(long)]
+  #[clap(long, value_parser)]
   error_recovery: bool,
 }
 


### PR DESCRIPTION
This adds C bindings for Parcel CSS, so that it can be used from programming languages other than Rust. So far, the basics of parsing, transforming, and printing stylesheets are supported. Eventually we might be able to expose information about rules and such as well if needed.

cc. @Jarred-Sumner