### PR TITLE
Playground: Fix wrong text color in output panel

### DIFF
--- a/playground/playground.js
+++ b/playground/playground.js
@@ -149,7 +149,7 @@ function update() {
     });
 
     compiled.value = dec.decode(res.code);
-    compiled.style.color = "initial";
+    compiled.style.color = "";
     compiledModules.value = JSON.stringify(res.exports, false, 2);
     compiledModules.hidden = !cssModules.checked;
     compiledDependencies.value = JSON.stringify(res.dependencies, false, 2);


### PR DESCRIPTION
Before:
![Screenshot 2022-08-22 at 18 35 46](https://user-images.githubusercontent.com/1062408/185973141-129e2de3-db50-498d-b8fe-4dcedd2216aa.png)

After:
![Screenshot 2022-08-22 at 18 35 53](https://user-images.githubusercontent.com/1062408/185973160-4d649e00-e791-4db9-a46c-fc2fe8158501.png)
