### PR TITLE
fix: Missing semicolon in Custom Media Queries

### DIFF
--- a/src/rules/custom_media.rs
+++ b/src/rules/custom_media.rs
@@ -31,6 +31,5 @@ impl<'i> ToCss for CustomMediaRule<'i> {
     dest.write_char(' ')?;
     self.query.to_css(dest)?;
     dest.write_char(';')
-
   }
 }

--- a/src/rules/custom_media.rs
+++ b/src/rules/custom_media.rs
@@ -29,6 +29,8 @@ impl<'i> ToCss for CustomMediaRule<'i> {
     dest.write_str("@custom-media ")?;
     self.name.to_css(dest)?;
     dest.write_char(' ')?;
-    self.query.to_css(dest)
+    self.query.to_css(dest)?;
+    dest.write_char(';')
+
   }
 }

--- a/tests/cli_integration_tests.rs
+++ b/tests/cli_integration_tests.rs
@@ -366,3 +366,22 @@ fn targets() -> Result<(), Box<dyn std::error::Error>> {
 
   Ok(())
 }
+
+#[test]
+fn preserve_custom_media() -> Result<(), Box<dyn std::error::Error>> {
+  let file = assert_fs::NamedTempFile::new("test.css")?;
+  file.write_str(
+    r#"
+      @custom-media --foo print;
+    "#,
+  )?;
+
+  let mut cmd = Command::cargo_bin("parcel_css")?;
+  cmd.arg(file.path());
+  cmd.arg("--custom-media");
+  cmd.assert().success().stdout(predicate::str::contains(indoc! {r#"
+    @custom-media --foo print;
+  "#}));
+
+  Ok(())
+}


### PR DESCRIPTION
fix #258

Adds a semicolon at the end of the `@custom-media` declaration.

@devongovett thank you for pointing me to the right file!