### PR TITLE
Suppress `UnsupportedPseudoClassOrElement` warning if `name` starts with `"-"`

### DIFF
--- a/src/selector.rs
+++ b/src/selector.rs
@@ -190,7 +190,9 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
       "window-inactive" => WebKitScrollbar(WebKitScrollbarPseudoClass::WindowInactive),
 
       _ => {
-        self.options.warn(loc.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name.clone())));
+        if !name.starts_with("_") {
+          self.options.warn(loc.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name.clone())));
+        }
         Custom(name.into())
       }
     };
@@ -217,7 +219,9 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
       "local" if self.options.css_modules.is_some() => Local(Box::new(parcel_selectors::parser::Selector::parse(self, parser)?)),
       "global" if self.options.css_modules.is_some() => Global(Box::new(parcel_selectors::parser::Selector::parse(self, parser)?)),
       _ => {
-        self.options.warn(parser.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name.clone())));
+        if !name.starts_with("-") {
+          self.options.warn(parser.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name.clone())));
+        }
         CustomFunction(name.into(), TokenList::parse(parser, &self.options, 0)?)
       },
     };
@@ -268,7 +272,9 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
       "-webkit-resizer" => WebKitScrollbar(WebKitScrollbarPseudoElement::Resizer),
 
       _ => {
-        self.options.warn(loc.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name.clone())));
+        if !name.starts_with("-") {
+          self.options.warn(loc.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name.clone())));
+        }
         Custom(name.into())
       }
     };
@@ -286,7 +292,9 @@ impl<'a, 'o, 'i> parcel_selectors::parser::Parser<'i> for SelectorParser<'a, 'o,
       "cue" => CueFunction(Box::new(Selector::parse(self, arguments)?)),
       "cue-region" => CueRegionFunction(Box::new(Selector::parse(self, arguments)?)),
       _ => {
-        self.options.warn(arguments.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name.clone())));
+        if !name.starts_with("-") {
+          self.options.warn(arguments.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(name.clone())));
+        }
         CustomFunction(name.into(), TokenList::parse(arguments, &self.options, 0)?)
       }
     };


### PR DESCRIPTION
https://github.com/parcel-bundler/parcel-css/issues/198#issuecomment-1231978976