### PR TITLE
fix: added types for wasm init default export

### DIFF
--- a/scripts/build-wasm.js
+++ b/scripts/build-wasm.js
@@ -20,7 +20,7 @@ let dts = fs.readFileSync(`${dir}/node/index.d.ts`, 'utf8');
 dts = dts.replace(/: Buffer/g, ': Uint8Array');
 dts += `
 /** Initializes the web assembly module. */
-export default function init(): Promise<void>;
+export default function init(input?: string | URL | Request): Promise<void>;
 `;
 fs.writeFileSync(`${dir}/npm/wasm/index.d.ts`, dts);
 fs.copyFileSync(`${dir}/node/targets.d.ts`, `${dir}/npm/wasm/targets.d.ts`);


### PR DESCRIPTION
I noticed while using the wasm module within Deno, the `init` function wasn't properly typed. This PR fixes that.