### PR TITLE
fix: match the spec so that feature-* in `tech()` becomes plural

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9452,8 +9452,8 @@ mod tests {
       "@font-face{src:url(test.ttc)format(\"collection\"),url(test.ttf)format(\"truetype\")}",
     );
     minify_test(
-      "@font-face {src: url(\"test.otf\") format(opentype) tech(feature-aat);}",
-      "@font-face{src:url(test.otf)format(\"opentype\")tech(feature-aat)}",
+      "@font-face {src: url(\"test.otf\") format(opentype) tech(features-aat);}",
+      "@font-face{src:url(test.otf)format(\"opentype\")tech(features-aat)}",
     );
     minify_test(
       "@font-face {src: url(\"test.woff\") format(woff) tech(color-colrv1);}",
@@ -9469,12 +9469,12 @@ mod tests {
     );
     // multiple tech
     minify_test(
-      "@font-face {src: url(\"test.woff\") format(woff) tech(feature-opentype, color-sbix);}",
-      "@font-face{src:url(test.woff)format(\"woff\")tech(feature-opentype,color-sbix)}",
+      "@font-face {src: url(\"test.woff\") format(woff) tech(features-opentype, color-sbix);}",
+      "@font-face{src:url(test.woff)format(\"woff\")tech(features-opentype,color-sbix)}",
     );
     minify_test(
-      "@font-face {src: url(\"test.woff\")   format(woff)    tech(incremental, color-svg, feature-graphite, feature-aat);}",
-      "@font-face{src:url(test.woff)format(\"woff\")tech(incremental,color-svg,feature-graphite,feature-aat)}",
+      "@font-face {src: url(\"test.woff\")   format(woff)    tech(incremental, color-svg, features-graphite, features-aat);}",
+      "@font-face{src:url(test.woff)format(\"woff\")tech(incremental,color-svg,features-graphite,features-aat)}",
     );
     // format() function must precede tech() if both are present
     minify_test(
@@ -9496,7 +9496,7 @@ mod tests {
     // TODO(CGQAQ): make this test pass when we have strict mode
     // ref: https://github.com/web-platform-tests/wpt/blob/9f8a6ccc41aa725e8f51f4f096f686313bb88d8d/css/css-fonts/parsing/font-face-src-tech.html#L45
     // error_test(
-    //   "@font-face {src: url(\"foo.ttf\") tech(feature-opentype) format(opentype);}",
+    //   "@font-face {src: url(\"foo.ttf\") tech(features-opentype) format(opentype);}",
     //   ParserError::AtRuleBodyInvalid,
     // );
     // error_test(
@@ -9504,7 +9504,7 @@ mod tests {
     //   ParserError::AtRuleBodyInvalid,
     // );
     // error_test(
-    //   "@font-face {src: url(\"foo.ttf\") tech(\"feature-opentype\");}",
+    //   "@font-face {src: url(\"foo.ttf\") tech(\"features-opentype\");}",
     //   ParserError::AtRuleBodyInvalid,
     // );
     // error_test(

--- a/src/rules/font_face.rs
+++ b/src/rules/font_face.rs
@@ -233,18 +233,18 @@ enum_property! {
   /// [src](https://drafts.csswg.org/css-fonts/#src-desc)
   /// property of an `@font-face` rule.
   pub enum FontTechnology {
-    /// A font feature tech descriptor in the `tech()`function of the
-    /// [src](https://drafts.csswg.org/css-fonts/#font-feature-tech-values)
+    /// A font features tech descriptor in the `tech()`function of the
+    /// [src](https://drafts.csswg.org/css-fonts/#font-features-tech-values)
     /// property of an `@font-face` rule.
     /// Supports OpenType Features.
     /// https://docs.microsoft.com/en-us/typography/opentype/spec/featurelist
-    "feature-opentype": FeatureOpentype,
+    "features-opentype": FeaturesOpentype,
     /// Supports Apple Advanced Typography Font Features.
     /// https://developer.apple.com/fonts/TrueType-Reference-Manual/RM09/AppendixF.html
-    "feature-aat": FeatureAat,
+    "features-aat": FeaturesAat,
     /// Supports Graphite Table Format.
     /// https://scripts.sil.org/cms/scripts/render_download.php?site_id=nrsi&format=file&media_id=GraphiteBinaryFormat_3_0&filename=GraphiteBinaryFormat_3_0.pdf
-    "feature-graphite": FeatureGraphite,
+    "features-graphite": FeaturesGraphite,
 
     /// A color font tech descriptor in the `tech()`function of the
     /// [src](https://drafts.csswg.org/css-fonts/#src-desc)


### PR DESCRIPTION
Previously `tech()` was implemented in https://github.com/parcel-bundler/parcel-css/pull/255, and this PR modifies `feature-*` to be plural to match the specification.

Spec changed in: https://github.com/w3c/csswg-drafts/issues/7663#issuecomment-1231534440
Chrome CL: https://chromium-review.googlesource.com/c/chromium/src/+/3856267

Fixes: #254

---
cc @CGQAQ 